### PR TITLE
feat: #1 Event Service 보일러플레이트 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,48 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store
+
+### Env ###
+.env
+*.env
+
+### Logs ###
+logs/
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# --- Build Stage ---
+FROM gradle:8.12-jdk21-alpine AS builder
+
+WORKDIR /app
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+RUN gradle dependencies --no-daemon || true
+
+COPY src ./src
+RUN gradle bootJar --no-daemon -x test
+
+# --- Runtime Stage ---
+FROM eclipse-temurin:21-jre-alpine
+
+WORKDIR /app
+
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+RUN chown appuser:appgroup app.jar
+USER appuser
+
+EXPOSE 8083
+
+ENTRYPOINT ["java", \
+  "-XX:+UseZGC", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "-Djava.security.egd=file:/dev/./urandom", \
+  "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,57 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.10'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.opentraum'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Spring Boot WebFlux (Reactive)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // R2DBC (Reactive Database Connectivity)
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+
+    // Kafka (Event Publishing)
+    implementation 'org.springframework.kafka:spring-kafka'
+
+    // Actuator + Prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.kafka:spring-kafka-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'opentraum-event-service'

--- a/src/main/java/com/opentraum/event/EventServiceApplication.java
+++ b/src/main/java/com/opentraum/event/EventServiceApplication.java
@@ -1,0 +1,12 @@
+package com.opentraum.event;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EventServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EventServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/opentraum/event/config/KafkaProducerConfig.java
+++ b/src/main/java/com/opentraum/event/config/KafkaProducerConfig.java
@@ -1,0 +1,38 @@
+package com.opentraum.event.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        configProps.put(ProducerConfig.ACKS_CONFIG, "all");
+        configProps.put(ProducerConfig.RETRIES_CONFIG, 3);
+        configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/opentraum/event/config/R2dbcConfig.java
+++ b/src/main/java/com/opentraum/event/config/R2dbcConfig.java
@@ -1,0 +1,24 @@
+package com.opentraum.event.config;
+
+import io.r2dbc.spi.ConnectionFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
+import org.springframework.r2dbc.connection.init.ConnectionFactoryInitializer;
+import org.springframework.r2dbc.connection.init.ResourceDatabasePopulator;
+
+@Configuration
+@EnableR2dbcAuditing
+public class R2dbcConfig {
+
+    @Bean
+    public ConnectionFactoryInitializer initializer(ConnectionFactory connectionFactory) {
+        ConnectionFactoryInitializer initializer = new ConnectionFactoryInitializer();
+        initializer.setConnectionFactory(connectionFactory);
+        initializer.setDatabasePopulator(
+                new ResourceDatabasePopulator(new ClassPathResource("schema.sql"))
+        );
+        return initializer;
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/controller/EventController.java
+++ b/src/main/java/com/opentraum/event/domain/controller/EventController.java
@@ -1,0 +1,75 @@
+package com.opentraum.event.domain.controller;
+
+import com.opentraum.event.domain.dto.EventCreateRequest;
+import com.opentraum.event.domain.dto.EventResponse;
+import com.opentraum.event.domain.dto.SeatResponse;
+import com.opentraum.event.domain.service.EventService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<EventResponse> createEvent(@Valid @RequestBody EventCreateRequest request) {
+        return eventService.createEvent(request);
+    }
+
+    @GetMapping("/{id}")
+    public Mono<EventResponse> getEvent(@PathVariable Long id) {
+        return eventService.getEventById(id);
+    }
+
+    @GetMapping
+    public Flux<EventResponse> getEventsByTenant(@RequestParam String tenantId) {
+        return eventService.getEventsByTenantId(tenantId);
+    }
+
+    @GetMapping("/search")
+    public Flux<EventResponse> searchEvents(
+            @RequestParam String tenantId,
+            @RequestParam String keyword) {
+        return eventService.searchEvents(tenantId, keyword);
+    }
+
+    @PutMapping("/{id}")
+    public Mono<EventResponse> updateEvent(
+            @PathVariable Long id,
+            @Valid @RequestBody EventCreateRequest request) {
+        return eventService.updateEvent(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public Mono<Void> deleteEvent(@PathVariable Long id) {
+        return eventService.deleteEvent(id);
+    }
+
+    @GetMapping("/{eventId}/seats")
+    public Flux<SeatResponse> getSeats(@PathVariable Long eventId) {
+        return eventService.getSeatsByEventId(eventId);
+    }
+
+    @GetMapping("/{eventId}/seats/available")
+    public Flux<SeatResponse> getAvailableSeats(@PathVariable Long eventId) {
+        return eventService.getAvailableSeatsByEventId(eventId);
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/dto/EventCreateRequest.java
+++ b/src/main/java/com/opentraum/event/domain/dto/EventCreateRequest.java
@@ -1,0 +1,41 @@
+package com.opentraum.event.domain.dto;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record EventCreateRequest(
+
+        @NotBlank(message = "테넌트 ID는 필수입니다")
+        String tenantId,
+
+        @NotBlank(message = "공연 제목은 필수입니다")
+        String title,
+
+        String description,
+
+        @NotBlank(message = "공연 장소는 필수입니다")
+        String venue,
+
+        @NotNull(message = "시작 일시는 필수입니다")
+        @Future(message = "시작 일시는 현재 이후여야 합니다")
+        LocalDateTime startDate,
+
+        @NotNull(message = "종료 일시는 필수입니다")
+        @Future(message = "종료 일시는 현재 이후여야 합니다")
+        LocalDateTime endDate,
+
+        @NotNull(message = "총 좌석 수는 필수입니다")
+        @Min(value = 1, message = "총 좌석 수는 1 이상이어야 합니다")
+        Integer totalSeats,
+
+        @NotNull(message = "가격은 필수입니다")
+        @Positive(message = "가격은 양수여야 합니다")
+        BigDecimal price
+) {
+}

--- a/src/main/java/com/opentraum/event/domain/dto/EventResponse.java
+++ b/src/main/java/com/opentraum/event/domain/dto/EventResponse.java
@@ -1,0 +1,41 @@
+package com.opentraum.event.domain.dto;
+
+import com.opentraum.event.domain.entity.Event;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record EventResponse(
+        Long id,
+        String tenantId,
+        String title,
+        String description,
+        String venue,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        Integer totalSeats,
+        Integer availableSeats,
+        BigDecimal price,
+        String status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+
+    public static EventResponse from(Event event) {
+        return new EventResponse(
+                event.getId(),
+                event.getTenantId(),
+                event.getTitle(),
+                event.getDescription(),
+                event.getVenue(),
+                event.getStartDate(),
+                event.getEndDate(),
+                event.getTotalSeats(),
+                event.getAvailableSeats(),
+                event.getPrice(),
+                event.getStatus(),
+                event.getCreatedAt(),
+                event.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/dto/SeatResponse.java
+++ b/src/main/java/com/opentraum/event/domain/dto/SeatResponse.java
@@ -1,0 +1,30 @@
+package com.opentraum.event.domain.dto;
+
+import com.opentraum.event.domain.entity.Seat;
+
+import java.math.BigDecimal;
+
+public record SeatResponse(
+        Long id,
+        Long eventId,
+        String section,
+        String row,
+        Integer number,
+        String grade,
+        BigDecimal price,
+        String status
+) {
+
+    public static SeatResponse from(Seat seat) {
+        return new SeatResponse(
+                seat.getId(),
+                seat.getEventId(),
+                seat.getSection(),
+                seat.getRow(),
+                seat.getNumber(),
+                seat.getGrade(),
+                seat.getPrice(),
+                seat.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/entity/Event.java
+++ b/src/main/java/com/opentraum/event/domain/entity/Event.java
@@ -1,0 +1,58 @@
+package com.opentraum.event.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table("events")
+public class Event {
+
+    @Id
+    private Long id;
+
+    @Column("tenant_id")
+    private String tenantId;
+
+    private String title;
+
+    private String description;
+
+    private String venue;
+
+    @Column("start_date")
+    private LocalDateTime startDate;
+
+    @Column("end_date")
+    private LocalDateTime endDate;
+
+    @Column("total_seats")
+    private Integer totalSeats;
+
+    @Column("available_seats")
+    private Integer availableSeats;
+
+    private BigDecimal price;
+
+    private String status;
+
+    @CreatedDate
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column("updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/opentraum/event/domain/entity/Seat.java
+++ b/src/main/java/com/opentraum/event/domain/entity/Seat.java
@@ -1,0 +1,39 @@
+package com.opentraum.event.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.math.BigDecimal;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table("seats")
+public class Seat {
+
+    @Id
+    private Long id;
+
+    @Column("event_id")
+    private Long eventId;
+
+    private String section;
+
+    @Column("seat_row")
+    private String row;
+
+    @Column("seat_number")
+    private Integer number;
+
+    private String grade;
+
+    private BigDecimal price;
+
+    private String status;
+}

--- a/src/main/java/com/opentraum/event/domain/repository/EventRepository.java
+++ b/src/main/java/com/opentraum/event/domain/repository/EventRepository.java
@@ -1,0 +1,20 @@
+package com.opentraum.event.domain.repository;
+
+import com.opentraum.event.domain.entity.Event;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+public interface EventRepository extends ReactiveCrudRepository<Event, Long> {
+
+    Flux<Event> findByTenantId(String tenantId);
+
+    Flux<Event> findByStatus(String status);
+
+    @Query("SELECT * FROM events WHERE tenant_id = :tenantId AND title ILIKE '%' || :keyword || '%'")
+    Flux<Event> searchByTenantIdAndTitle(String tenantId, String keyword);
+
+    Flux<Event> findByTenantIdAndStatus(String tenantId, String status);
+}

--- a/src/main/java/com/opentraum/event/domain/repository/SeatRepository.java
+++ b/src/main/java/com/opentraum/event/domain/repository/SeatRepository.java
@@ -1,0 +1,16 @@
+package com.opentraum.event.domain.repository;
+
+import com.opentraum.event.domain.entity.Seat;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+
+@Repository
+public interface SeatRepository extends ReactiveCrudRepository<Seat, Long> {
+
+    Flux<Seat> findByEventId(Long eventId);
+
+    Flux<Seat> findByEventIdAndStatus(Long eventId, String status);
+
+    Flux<Seat> findByEventIdAndGrade(Long eventId, String grade);
+}

--- a/src/main/java/com/opentraum/event/domain/service/EventService.java
+++ b/src/main/java/com/opentraum/event/domain/service/EventService.java
@@ -1,0 +1,26 @@
+package com.opentraum.event.domain.service;
+
+import com.opentraum.event.domain.dto.EventCreateRequest;
+import com.opentraum.event.domain.dto.EventResponse;
+import com.opentraum.event.domain.dto.SeatResponse;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface EventService {
+
+    Mono<EventResponse> createEvent(EventCreateRequest request);
+
+    Mono<EventResponse> getEventById(Long id);
+
+    Flux<EventResponse> getEventsByTenantId(String tenantId);
+
+    Flux<EventResponse> searchEvents(String tenantId, String keyword);
+
+    Mono<EventResponse> updateEvent(Long id, EventCreateRequest request);
+
+    Mono<Void> deleteEvent(Long id);
+
+    Flux<SeatResponse> getSeatsByEventId(Long eventId);
+
+    Flux<SeatResponse> getAvailableSeatsByEventId(Long eventId);
+}

--- a/src/main/java/com/opentraum/event/domain/service/EventServiceImpl.java
+++ b/src/main/java/com/opentraum/event/domain/service/EventServiceImpl.java
@@ -1,0 +1,124 @@
+package com.opentraum.event.domain.service;
+
+import com.opentraum.event.domain.dto.EventCreateRequest;
+import com.opentraum.event.domain.dto.EventResponse;
+import com.opentraum.event.domain.dto.SeatResponse;
+import com.opentraum.event.domain.entity.Event;
+import com.opentraum.event.domain.repository.EventRepository;
+import com.opentraum.event.domain.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventServiceImpl implements EventService {
+
+    private final EventRepository eventRepository;
+    private final SeatRepository seatRepository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    private static final String EVENT_TOPIC = "event-service.events";
+
+    @Override
+    @Transactional
+    public Mono<EventResponse> createEvent(EventCreateRequest request) {
+        Event event = Event.builder()
+                .tenantId(request.tenantId())
+                .title(request.title())
+                .description(request.description())
+                .venue(request.venue())
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .totalSeats(request.totalSeats())
+                .availableSeats(request.totalSeats())
+                .price(request.price())
+                .status("DRAFT")
+                .build();
+
+        return eventRepository.save(event)
+                .doOnSuccess(saved -> {
+                    log.info("Event created: id={}, tenantId={}, title={}",
+                            saved.getId(), saved.getTenantId(), saved.getTitle());
+                    kafkaTemplate.send(EVENT_TOPIC, saved.getTenantId(),
+                            new EventPublishedMessage("EVENT_CREATED", saved.getId(), saved.getTenantId()));
+                })
+                .map(EventResponse::from);
+    }
+
+    @Override
+    public Mono<EventResponse> getEventById(Long id) {
+        return eventRepository.findById(id)
+                .map(EventResponse::from)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Event not found: " + id)));
+    }
+
+    @Override
+    public Flux<EventResponse> getEventsByTenantId(String tenantId) {
+        return eventRepository.findByTenantId(tenantId)
+                .map(EventResponse::from);
+    }
+
+    @Override
+    public Flux<EventResponse> searchEvents(String tenantId, String keyword) {
+        return eventRepository.searchByTenantIdAndTitle(tenantId, keyword)
+                .map(EventResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public Mono<EventResponse> updateEvent(Long id, EventCreateRequest request) {
+        return eventRepository.findById(id)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Event not found: " + id)))
+                .flatMap(existing -> {
+                    existing.setTitle(request.title());
+                    existing.setDescription(request.description());
+                    existing.setVenue(request.venue());
+                    existing.setStartDate(request.startDate());
+                    existing.setEndDate(request.endDate());
+                    existing.setTotalSeats(request.totalSeats());
+                    existing.setPrice(request.price());
+                    return eventRepository.save(existing);
+                })
+                .doOnSuccess(updated -> {
+                    log.info("Event updated: id={}, title={}", updated.getId(), updated.getTitle());
+                    kafkaTemplate.send(EVENT_TOPIC, updated.getTenantId(),
+                            new EventPublishedMessage("EVENT_UPDATED", updated.getId(), updated.getTenantId()));
+                })
+                .map(EventResponse::from);
+    }
+
+    @Override
+    @Transactional
+    public Mono<Void> deleteEvent(Long id) {
+        return eventRepository.findById(id)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Event not found: " + id)))
+                .flatMap(event -> {
+                    log.info("Event deleted: id={}, tenantId={}", event.getId(), event.getTenantId());
+                    kafkaTemplate.send(EVENT_TOPIC, event.getTenantId(),
+                            new EventPublishedMessage("EVENT_DELETED", event.getId(), event.getTenantId()));
+                    return eventRepository.deleteById(id);
+                });
+    }
+
+    @Override
+    public Flux<SeatResponse> getSeatsByEventId(Long eventId) {
+        return seatRepository.findByEventId(eventId)
+                .map(SeatResponse::from);
+    }
+
+    @Override
+    public Flux<SeatResponse> getAvailableSeatsByEventId(Long eventId) {
+        return seatRepository.findByEventIdAndStatus(eventId, "AVAILABLE")
+                .map(SeatResponse::from);
+    }
+
+    private record EventPublishedMessage(String type, Long eventId, String tenantId) {
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,69 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: opentraum-event-service
+
+  r2dbc:
+    url: r2dbc:postgresql://localhost:5432/opentraum_event
+    username: ${DB_USERNAME:opentraum}
+    password: ${DB_PASSWORD:opentraum}
+    pool:
+      initial-size: 5
+      max-size: 20
+      max-idle-time: 30m
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
+
+  sql:
+    init:
+      mode: always
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  endpoint:
+    health:
+      show-details: when-authorized
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+logging:
+  level:
+    root: INFO
+    com.opentraum.event: DEBUG
+    org.springframework.r2dbc: DEBUG
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  r2dbc:
+    url: r2dbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:opentraum_event}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+
+  sql:
+    init:
+      mode: never
+
+logging:
+  level:
+    root: WARN
+    com.opentraum.event: INFO
+    org.springframework.r2dbc: WARN

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,34 @@
+CREATE TABLE IF NOT EXISTS events (
+    id              BIGSERIAL       PRIMARY KEY,
+    tenant_id       VARCHAR(64)     NOT NULL,
+    title           VARCHAR(255)    NOT NULL,
+    description     TEXT,
+    venue           VARCHAR(255)    NOT NULL,
+    start_date      TIMESTAMP       NOT NULL,
+    end_date        TIMESTAMP       NOT NULL,
+    total_seats     INTEGER         NOT NULL DEFAULT 0,
+    available_seats INTEGER         NOT NULL DEFAULT 0,
+    price           NUMERIC(12, 2)  NOT NULL DEFAULT 0,
+    status          VARCHAR(32)     NOT NULL DEFAULT 'DRAFT',
+    created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_tenant_id ON events (tenant_id);
+CREATE INDEX IF NOT EXISTS idx_events_status ON events (status);
+CREATE INDEX IF NOT EXISTS idx_events_tenant_status ON events (tenant_id, status);
+
+CREATE TABLE IF NOT EXISTS seats (
+    id              BIGSERIAL       PRIMARY KEY,
+    event_id        BIGINT          NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    section         VARCHAR(64)     NOT NULL,
+    seat_row        VARCHAR(16)     NOT NULL,
+    seat_number     INTEGER         NOT NULL,
+    grade           VARCHAR(32)     NOT NULL,
+    price           NUMERIC(12, 2)  NOT NULL DEFAULT 0,
+    status          VARCHAR(32)     NOT NULL DEFAULT 'AVAILABLE'
+);
+
+CREATE INDEX IF NOT EXISTS idx_seats_event_id ON seats (event_id);
+CREATE INDEX IF NOT EXISTS idx_seats_event_status ON seats (event_id, status);
+CREATE INDEX IF NOT EXISTS idx_seats_event_grade ON seats (event_id, grade);


### PR DESCRIPTION
## 개요
OpenTraum 공연/이벤트 관리 서비스의 보일러플레이트를 구축합니다.

Closes #1

## 변경 사항

### 프로젝트 설정
- Spring Boot 3.5.10 + Java 21 + WebFlux + R2DBC + Kafka
- Gradle 8.12, Dockerfile 멀티 스테이지 빌드

### 도메인 모델
- **Event**: 공연/이벤트 엔티티 (title, venue, dates, seats, price, status)
- **Seat**: 좌석 엔티티 (section, row, number, grade, price, status)

### 서비스 계층
- **EventService**: 이벤트 CRUD + 검색 + 좌석 관리

### API 엔드포인트
| Method | Endpoint | 설명 |
|--------|----------|------|
| POST | /api/v1/events | 이벤트 생성 |
| GET | /api/v1/events/{id} | 이벤트 상세 |
| GET | /api/v1/events | 이벤트 목록/검색 |
| PUT | /api/v1/events/{id} | 이벤트 수정 |
| DELETE | /api/v1/events/{id} | 이벤트 삭제 |
| GET | /api/v1/events/{eventId}/seats | 좌석 목록 |

### 인프라
- application.yml (포트 8083), schema.sql, Dockerfile

## 테스트 계획
- [ ] 프로젝트 빌드 성공 확인
- [ ] Actuator health endpoint 확인
- [ ] 이벤트 CRUD API 동작 확인
- [ ] 좌석 조회 API 확인