### PR TITLE
feat: #3 FairTicket 코드 마이그레이션 - Concert/Seat 도메인

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     runtimeOnly 'org.postgresql:r2dbc-postgresql'
 
+    // Redis (Reactive)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
     // Kafka (Event Publishing)
     implementation 'org.springframework.kafka:spring-kafka'
 
@@ -40,6 +43,9 @@ dependencies {
 
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Swagger (SpringDoc OpenAPI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:2.8.6'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/opentraum/event/domain/concert/controller/ConcertController.java
+++ b/src/main/java/com/opentraum/event/domain/concert/controller/ConcertController.java
@@ -1,0 +1,38 @@
+package com.opentraum.event.domain.concert.controller;
+
+import com.opentraum.event.domain.concert.dto.ConcertResponse;
+import com.opentraum.event.domain.concert.service.ConcertService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Concert", description = "공연 조회 API")
+@RestController
+@RequestMapping("/api/v1/concerts")
+@RequiredArgsConstructor
+public class ConcertController {
+
+    private final ConcertService concertService;
+
+    @Operation(summary = "전체 공연 목록 조회")
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<ConcertResponse> getConcerts() {
+        return concertService.getConcerts();
+    }
+
+    @Operation(summary = "테넌트별 공연 목록 조회")
+    @GetMapping(value = "/tenant/{tenantId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Flux<ConcertResponse> getConcertsByTenant(@PathVariable String tenantId) {
+        return concertService.getConcertsByTenantId(tenantId);
+    }
+
+    @Operation(summary = "공연 상세 조회")
+    @GetMapping(value = "/{concertId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public Mono<ConcertResponse> getConcertById(@PathVariable Long concertId) {
+        return concertService.getConcertById(concertId);
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/concert/controller/ScheduleController.java
+++ b/src/main/java/com/opentraum/event/domain/concert/controller/ScheduleController.java
@@ -1,0 +1,39 @@
+package com.opentraum.event.domain.concert.controller;
+
+import com.opentraum.event.domain.concert.dto.GradeResponse;
+import com.opentraum.event.domain.concert.service.ScheduleService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Tag(name = "Schedule", description = "회차별 등급/구역 조회 API")
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @Operation(summary = "등급 목록 조회")
+    @GetMapping("/{scheduleId}/grades")
+    public Mono<ResponseEntity<List<GradeResponse>>> getGrades(
+            @PathVariable Long scheduleId) {
+        return scheduleService.getGradesByScheduleId(scheduleId)
+                .collectList()
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "등급별 구역 목록 조회")
+    @GetMapping("/{scheduleId}/grades/{grade}/zones")
+    public Mono<ResponseEntity<List<String>>> getZonesByGrade(
+            @PathVariable Long scheduleId,
+            @PathVariable String grade) {
+        return scheduleService.getZonesByGrade(scheduleId, grade)
+                .map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/concert/dto/ConcertResponse.java
+++ b/src/main/java/com/opentraum/event/domain/concert/dto/ConcertResponse.java
@@ -1,0 +1,25 @@
+package com.opentraum.event.domain.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ConcertResponse {
+
+    private Long id;
+    private String title;
+    private String artist;
+    private String venue;
+    private String tenantId;
+    private String saleStatus;   // "on-sale" / "coming-soon" / "sold-out"
+    private String saleDate;     // UPCOMING일 때만, ISO-8601 (null 가능)
+    private List<ScheduleResponse> dates;
+    private List<GradeDetailResponse> grades;
+}

--- a/src/main/java/com/opentraum/event/domain/concert/dto/GradeDetailResponse.java
+++ b/src/main/java/com/opentraum/event/domain/concert/dto/GradeDetailResponse.java
@@ -1,0 +1,19 @@
+package com.opentraum.event.domain.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradeDetailResponse {
+
+    private String id;           // grade 소문자 (예: "vip", "s", "a")
+    private String label;        // grade 원본 (예: "VIP", "S", "A")
+    private int price;
+    private int totalSeats;      // zones에서 해당 grade의 seat_count 합산
+    private int availableSeats;  // seats에서 해당 grade의 status='AVAILABLE' 카운트
+}

--- a/src/main/java/com/opentraum/event/domain/concert/dto/GradeResponse.java
+++ b/src/main/java/com/opentraum/event/domain/concert/dto/GradeResponse.java
@@ -1,0 +1,15 @@
+package com.opentraum.event.domain.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradeResponse {
+    private String grade;
+    private Integer price;
+}

--- a/src/main/java/com/opentraum/event/domain/concert/dto/ScheduleResponse.java
+++ b/src/main/java/com/opentraum/event/domain/concert/dto/ScheduleResponse.java
@@ -1,0 +1,19 @@
+package com.opentraum.event.domain.concert.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleResponse {
+
+    private Long id;
+    private String date;   // yyyy-MM-dd
+    private String time;   // HH:mm
+    private String venue;
+    private boolean available;  // schedules.status == "OPEN"
+}

--- a/src/main/java/com/opentraum/event/domain/concert/entity/Concert.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/Concert.java
@@ -1,0 +1,31 @@
+package com.opentraum.event.domain.concert.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("concerts")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Concert {
+
+    @Id
+    private Long id;
+
+    private String title;
+
+    private String artist;
+
+    private String venue;
+
+    private String tenantId;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/opentraum/event/domain/concert/entity/Grade.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/Grade.java
@@ -1,0 +1,23 @@
+package com.opentraum.event.domain.concert.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("grades")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Grade {
+
+    @Id
+    private Long id;
+
+    private Long scheduleId;
+
+    private String grade;
+
+    private Integer price;
+}

--- a/src/main/java/com/opentraum/event/domain/concert/entity/Schedule.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/Schedule.java
@@ -1,0 +1,33 @@
+package com.opentraum.event.domain.concert.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("schedules")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Schedule {
+
+    @Id
+    private Long id;
+
+    private Long concertId;
+
+    private LocalDateTime dateTime;
+
+    private Integer totalSeats;
+
+    private LocalDateTime ticketOpenAt;
+
+    private LocalDateTime ticketCloseAt;
+
+    private String status;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/opentraum/event/domain/concert/entity/ScheduleStatus.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/ScheduleStatus.java
@@ -1,0 +1,8 @@
+package com.opentraum.event.domain.concert.entity;
+
+public enum ScheduleStatus {
+    UPCOMING,
+    OPEN,
+    CLOSED,
+    COMPLETED
+}

--- a/src/main/java/com/opentraum/event/domain/concert/entity/Zone.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/Zone.java
@@ -1,0 +1,25 @@
+package com.opentraum.event.domain.concert.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("zones")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Zone {
+
+    @Id
+    private Long id;
+
+    private Long scheduleId;
+
+    private String zone;
+
+    private String grade;
+
+    private Integer seatCount;
+}

--- a/src/main/java/com/opentraum/event/domain/concert/repository/ConcertRepository.java
+++ b/src/main/java/com/opentraum/event/domain/concert/repository/ConcertRepository.java
@@ -1,0 +1,10 @@
+package com.opentraum.event.domain.concert.repository;
+
+import com.opentraum.event.domain.concert.entity.Concert;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+
+public interface ConcertRepository extends ReactiveCrudRepository<Concert, Long> {
+
+    Flux<Concert> findByTenantId(String tenantId);
+}

--- a/src/main/java/com/opentraum/event/domain/concert/repository/GradeRepository.java
+++ b/src/main/java/com/opentraum/event/domain/concert/repository/GradeRepository.java
@@ -1,0 +1,10 @@
+package com.opentraum.event.domain.concert.repository;
+
+import com.opentraum.event.domain.concert.entity.Grade;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+
+public interface GradeRepository extends ReactiveCrudRepository<Grade, Long> {
+
+    Flux<Grade> findByScheduleId(Long scheduleId);
+}

--- a/src/main/java/com/opentraum/event/domain/concert/repository/ScheduleRepository.java
+++ b/src/main/java/com/opentraum/event/domain/concert/repository/ScheduleRepository.java
@@ -1,0 +1,16 @@
+package com.opentraum.event.domain.concert.repository;
+
+import com.opentraum.event.domain.concert.entity.Schedule;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+
+import java.time.LocalDateTime;
+
+public interface ScheduleRepository extends ReactiveCrudRepository<Schedule, Long> {
+
+    Flux<Schedule> findByConcertId(Long concertId);
+
+    Flux<Schedule> findByTicketOpenAtLessThanEqual(LocalDateTime time);
+
+    Flux<Schedule> findByTicketOpenAtLessThanEqualAndStatusNot(LocalDateTime time, String status);
+}

--- a/src/main/java/com/opentraum/event/domain/concert/repository/ZoneRepository.java
+++ b/src/main/java/com/opentraum/event/domain/concert/repository/ZoneRepository.java
@@ -1,0 +1,17 @@
+package com.opentraum.event.domain.concert.repository;
+
+import com.opentraum.event.domain.concert.entity.Zone;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface ZoneRepository extends ReactiveCrudRepository<Zone, Long> {
+
+    Flux<Zone> findByScheduleId(Long scheduleId);
+
+    Flux<Zone> findByScheduleIdAndGrade(Long scheduleId, String grade);
+
+    Mono<Zone> findByScheduleIdAndZone(Long scheduleId, String zone);
+
+    Mono<Zone> findByScheduleIdAndGradeAndZone(Long scheduleId, String grade, String zone);
+}

--- a/src/main/java/com/opentraum/event/domain/concert/service/ConcertService.java
+++ b/src/main/java/com/opentraum/event/domain/concert/service/ConcertService.java
@@ -1,0 +1,174 @@
+package com.opentraum.event.domain.concert.service;
+
+import com.opentraum.event.domain.concert.dto.ConcertResponse;
+import com.opentraum.event.domain.concert.dto.GradeDetailResponse;
+import com.opentraum.event.domain.concert.dto.ScheduleResponse;
+import com.opentraum.event.domain.concert.entity.Concert;
+import com.opentraum.event.domain.concert.entity.Grade;
+import com.opentraum.event.domain.concert.entity.Schedule;
+import com.opentraum.event.domain.concert.entity.ScheduleStatus;
+import com.opentraum.event.domain.concert.entity.Zone;
+import com.opentraum.event.domain.concert.repository.ConcertRepository;
+import com.opentraum.event.domain.concert.repository.GradeRepository;
+import com.opentraum.event.domain.concert.repository.ScheduleRepository;
+import com.opentraum.event.domain.concert.repository.ZoneRepository;
+import com.opentraum.event.domain.seat.dto.GradeSeatCount;
+import com.opentraum.event.domain.seat.repository.SeatRepository;
+import com.opentraum.event.global.exception.BusinessException;
+import com.opentraum.event.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ConcertService {
+
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter TIME_FORMAT = DateTimeFormatter.ofPattern("HH:mm");
+    private static final DateTimeFormatter ISO_DATE_TIME = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+    private final ConcertRepository concertRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final GradeRepository gradeRepository;
+    private final ZoneRepository zoneRepository;
+    private final SeatRepository seatRepository;
+
+    public Flux<ConcertResponse> getConcerts() {
+        return concertRepository.findAll()
+                .flatMap(this::toConcertResponse);
+    }
+
+    public Flux<ConcertResponse> getConcertsByTenantId(String tenantId) {
+        return concertRepository.findByTenantId(tenantId)
+                .flatMap(this::toConcertResponse);
+    }
+
+    public Mono<ConcertResponse> getConcertById(Long concertId) {
+        return concertRepository.findById(concertId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.CONCERT_NOT_FOUND)))
+                .flatMap(this::toConcertResponse);
+    }
+
+    private Mono<ConcertResponse> toConcertResponse(Concert concert) {
+        return scheduleRepository.findByConcertId(concert.getId())
+                .collectList()
+                .flatMap(schedules -> buildResponse(concert, schedules));
+    }
+
+    private Mono<ConcertResponse> buildResponse(Concert concert, List<Schedule> schedules) {
+        String saleStatus = deriveSaleStatus(schedules);
+        String saleDate = deriveSaleDate(schedules);
+        List<ScheduleResponse> dates = schedules.stream()
+                .map(s -> ScheduleResponse.builder()
+                        .id(s.getId())
+                        .date(s.getDateTime().format(DATE_FORMAT))
+                        .time(s.getDateTime().format(TIME_FORMAT))
+                        .venue(concert.getVenue())
+                        .available(ScheduleStatus.OPEN.name().equals(s.getStatus()))
+                        .build())
+                .collect(Collectors.toList());
+
+        if (schedules.isEmpty()) {
+            return Mono.just(ConcertResponse.builder()
+                    .id(concert.getId())
+                    .title(concert.getTitle())
+                    .artist(concert.getArtist())
+                    .venue(concert.getVenue())
+                    .tenantId(concert.getTenantId())
+                    .saleStatus("sold-out")
+                    .saleDate(null)
+                    .dates(List.of())
+                    .grades(List.of())
+                    .build());
+        }
+
+        Schedule refSchedule = chooseReferenceScheduleForGrades(schedules);
+        return buildGrades(refSchedule)
+                .map(grades -> ConcertResponse.builder()
+                        .id(concert.getId())
+                        .title(concert.getTitle())
+                        .artist(concert.getArtist())
+                        .venue(concert.getVenue())
+                        .tenantId(concert.getTenantId())
+                        .saleStatus(saleStatus)
+                        .saleDate(saleDate)
+                        .dates(dates)
+                        .grades(grades)
+                        .build());
+    }
+
+    private String deriveSaleStatus(List<Schedule> schedules) {
+        if (schedules.isEmpty()) return "sold-out";
+        boolean anyOpen = schedules.stream().anyMatch(s -> ScheduleStatus.OPEN.name().equals(s.getStatus()));
+        boolean allUpcoming = schedules.stream().allMatch(s -> ScheduleStatus.UPCOMING.name().equals(s.getStatus()));
+        boolean allClosedOrCompleted = schedules.stream().allMatch(s ->
+                ScheduleStatus.CLOSED.name().equals(s.getStatus())
+                        || ScheduleStatus.COMPLETED.name().equals(s.getStatus()));
+        if (anyOpen) return "on-sale";
+        if (allUpcoming) return "coming-soon";
+        if (allClosedOrCompleted) return "sold-out";
+        return "on-sale"; // mixed
+    }
+
+    private String deriveSaleDate(List<Schedule> schedules) {
+        return schedules.stream()
+                .filter(s -> ScheduleStatus.UPCOMING.name().equals(s.getStatus()))
+                .findFirst()
+                .map(s -> s.getTicketOpenAt() != null ? s.getTicketOpenAt().format(ISO_DATE_TIME) : null)
+                .orElse(null);
+    }
+
+    private Schedule chooseReferenceScheduleForGrades(List<Schedule> schedules) {
+        return schedules.stream()
+                .filter(s -> ScheduleStatus.OPEN.name().equals(s.getStatus()))
+                .findFirst()
+                .or(() -> schedules.stream()
+                        .filter(s -> ScheduleStatus.UPCOMING.name().equals(s.getStatus()))
+                        .findFirst())
+                .orElse(schedules.get(0));
+    }
+
+    private Mono<List<GradeDetailResponse>> buildGrades(Schedule refSchedule) {
+        Mono<List<Grade>> gradesMono =
+                gradeRepository.findByScheduleId(refSchedule.getId()).collectList();
+        Mono<Map<String, Integer>> totalByGrade = zoneRepository.findByScheduleId(refSchedule.getId())
+                .collectList()
+                .map(zones -> zones.stream()
+                        .collect(Collectors.groupingBy(Zone::getGrade,
+                                Collectors.summingInt(z -> z.getSeatCount() != null ? z.getSeatCount() : 0))));
+        Mono<Map<String, Long>> availableByGrade = seatRepository
+                .findAvailableSeatCountByScheduleIdGroupByGrade(refSchedule.getId())
+                .collectList()
+                .map(list -> list.stream()
+                        .collect(Collectors.toMap(GradeSeatCount::getGrade, g -> g.getCount() != null ? g.getCount() : 0L)));
+
+        return Mono.zip(gradesMono, totalByGrade, availableByGrade)
+                .map(tuple -> {
+                    List<Grade> grades = tuple.getT1();
+                    Map<String, Integer> totalMap = tuple.getT2();
+                    Map<String, Long> availableMap = tuple.getT3();
+                    List<GradeDetailResponse> result = new ArrayList<>();
+                    for (Grade g : grades) {
+                        String grade = g.getGrade();
+                        int totalSeats = totalMap.getOrDefault(grade, 0);
+                        int availableSeats = Math.toIntExact(availableMap.getOrDefault(grade, 0L));
+                        result.add(GradeDetailResponse.builder()
+                                .id(grade != null ? grade.toLowerCase() : "")
+                                .label(grade != null ? grade : "")
+                                .price(g.getPrice() != null ? g.getPrice() : 0)
+                                .totalSeats(totalSeats)
+                                .availableSeats(availableSeats)
+                                .build());
+                    }
+                    return result;
+                });
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/concert/service/ScheduleService.java
+++ b/src/main/java/com/opentraum/event/domain/concert/service/ScheduleService.java
@@ -1,0 +1,53 @@
+package com.opentraum.event.domain.concert.service;
+
+import com.opentraum.event.domain.concert.dto.GradeResponse;
+import com.opentraum.event.domain.concert.entity.Schedule;
+import com.opentraum.event.domain.concert.repository.GradeRepository;
+import com.opentraum.event.domain.concert.repository.ScheduleRepository;
+import com.opentraum.event.domain.concert.repository.ZoneRepository;
+import com.opentraum.event.global.exception.BusinessException;
+import com.opentraum.event.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduleService {
+
+    private final GradeRepository gradeRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final ZoneRepository zoneRepository;
+
+    public Mono<Schedule> findScheduleOrThrow(Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)));
+    }
+
+    public Flux<GradeResponse> getGradesByScheduleId(Long scheduleId) {
+        return gradeRepository.findByScheduleId(scheduleId)
+                .map(g -> GradeResponse.builder()
+                        .grade(g.getGrade())
+                        .price(g.getPrice())
+                        .build());
+    }
+
+    public Mono<List<String>> getZonesByGrade(Long scheduleId, String grade) {
+        return zoneRepository.findByScheduleIdAndGrade(scheduleId, grade)
+                .map(zone -> zone.getZone())
+                .collectList();
+    }
+
+    public Mono<Void> validateGradeAndZone(Long scheduleId, String grade, String zone) {
+        return zoneRepository.findByScheduleIdAndGradeAndZone(scheduleId, grade, zone)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.INVALID_GRADE_ZONE)))
+                .then();
+    }
+
+    public Flux<String> getZoneNamesByScheduleId(Long scheduleId) {
+        return zoneRepository.findByScheduleId(scheduleId).map(zone -> zone.getZone());
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/seat/controller/SeatPoolController.java
+++ b/src/main/java/com/opentraum/event/domain/seat/controller/SeatPoolController.java
@@ -1,0 +1,28 @@
+package com.opentraum.event.domain.seat.controller;
+
+import com.opentraum.event.domain.seat.service.SeatPoolService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Seat Pool", description = "좌석 풀 관리 API (관리자용)")
+@RestController
+@RequestMapping("/api/v1/admin/seats")
+@RequiredArgsConstructor
+public class SeatPoolController {
+
+    private final SeatPoolService seatPoolService;
+
+    @Operation(summary = "좌석 풀 초기화")
+    @PostMapping("/{scheduleId}/initialize")
+    public Mono<ResponseEntity<Void>> initializeSeatPools(
+            @Parameter(required = true)
+            @PathVariable Long scheduleId) {
+        return seatPoolService.initializeSeatPools(scheduleId)
+                .then(Mono.just(ResponseEntity.ok().build()));
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/seat/dto/GradeSeatCount.java
+++ b/src/main/java/com/opentraum/event/domain/seat/dto/GradeSeatCount.java
@@ -1,0 +1,16 @@
+package com.opentraum.event.domain.seat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 등급별 좌석 수 집계 결과 (GROUP BY grade 쿼리용)
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GradeSeatCount {
+    private String grade;
+    private Long count;
+}

--- a/src/main/java/com/opentraum/event/domain/seat/dto/SeatSelectionRequest.java
+++ b/src/main/java/com/opentraum/event/domain/seat/dto/SeatSelectionRequest.java
@@ -1,0 +1,13 @@
+package com.opentraum.event.domain.seat.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SeatSelectionRequest {
+    private Long scheduleId;
+    private String grade;
+    private String zone;
+    private String seatNumber;
+}

--- a/src/main/java/com/opentraum/event/domain/seat/dto/SeatSelectionResponse.java
+++ b/src/main/java/com/opentraum/event/domain/seat/dto/SeatSelectionResponse.java
@@ -1,0 +1,18 @@
+package com.opentraum.event.domain.seat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SeatSelectionResponse {
+    private Long scheduleId;
+    private String grade;
+    private String zone;
+    private String seatNumber;
+    private LocalDateTime holdExpiresAt;
+    private LocalDateTime paymentDeadline;
+    private String message;
+}

--- a/src/main/java/com/opentraum/event/domain/seat/dto/ZoneSeatAssignmentResponse.java
+++ b/src/main/java/com/opentraum/event/domain/seat/dto/ZoneSeatAssignmentResponse.java
@@ -1,0 +1,16 @@
+package com.opentraum.event.domain.seat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 추첨 좌석 배정 결과 (응답/반환용). 구역 + 좌석 번호.
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ZoneSeatAssignmentResponse {
+    private String zone;
+    private String seatNumber;
+}

--- a/src/main/java/com/opentraum/event/domain/seat/entity/Seat.java
+++ b/src/main/java/com/opentraum/event/domain/seat/entity/Seat.java
@@ -1,0 +1,33 @@
+package com.opentraum.event.domain.seat.entity;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("seats")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Seat {
+
+    @Id
+    private Long id;
+
+    private Long scheduleId;
+
+    private String grade;
+
+    private String zone;
+
+    private String seatNumber;
+
+    private Integer price;
+
+    private String status;
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/opentraum/event/domain/seat/entity/SeatStatus.java
+++ b/src/main/java/com/opentraum/event/domain/seat/entity/SeatStatus.java
@@ -1,0 +1,7 @@
+package com.opentraum.event.domain.seat.entity;
+
+public enum SeatStatus {
+    AVAILABLE,
+    HELD,
+    SOLD
+}

--- a/src/main/java/com/opentraum/event/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/opentraum/event/domain/seat/repository/SeatRepository.java
@@ -1,0 +1,39 @@
+package com.opentraum.event.domain.seat.repository;
+
+import com.opentraum.event.domain.seat.dto.GradeSeatCount;
+import com.opentraum.event.domain.seat.entity.Seat;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface SeatRepository extends ReactiveCrudRepository<Seat, Long> {
+
+    @Modifying
+    @Query("UPDATE seats SET status = :status WHERE schedule_id = :scheduleId AND zone = :zone AND seat_number = :seatNumber")
+    Mono<Integer> updateStatusByScheduleIdAndZoneAndSeatNumber(
+            @Param("status") String status,
+            @Param("scheduleId") Long scheduleId,
+            @Param("zone") String zone,
+            @Param("seatNumber") String seatNumber);
+
+    Mono<Long> countByScheduleIdAndGrade(Long scheduleId, String grade);
+
+    Flux<Seat> findByScheduleId(Long scheduleId);
+
+    Flux<Seat> findByScheduleIdAndZone(Long scheduleId, String zone);
+
+    Mono<Seat> findByScheduleIdAndZoneAndSeatNumber(Long scheduleId, String zone, String seatNumber);
+
+    Flux<Seat> findByScheduleIdAndZoneAndSeatNumberIn(Long scheduleId, String zone, List<String> seatNumbers);
+
+    @Query("SELECT grade, COUNT(*) as count FROM seats WHERE schedule_id = :scheduleId GROUP BY grade")
+    Flux<GradeSeatCount> findSeatCountByScheduleIdGroupByGrade(Long scheduleId);
+
+    @Query("SELECT grade, COUNT(*) as count FROM seats WHERE schedule_id = :scheduleId AND status = 'AVAILABLE' GROUP BY grade")
+    Flux<GradeSeatCount> findAvailableSeatCountByScheduleIdGroupByGrade(@Param("scheduleId") Long scheduleId);
+}

--- a/src/main/java/com/opentraum/event/domain/seat/service/SeatHoldService.java
+++ b/src/main/java/com/opentraum/event/domain/seat/service/SeatHoldService.java
@@ -1,0 +1,78 @@
+package com.opentraum.event.domain.seat.service;
+
+import com.opentraum.event.domain.seat.entity.SeatStatus;
+import com.opentraum.event.domain.seat.repository.SeatRepository;
+import com.opentraum.event.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatHoldService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final SeatRepository seatRepository;
+
+    private static final Duration HOLD_TTL = Duration.ofMinutes(10);
+
+    /**
+     * 좌석 임시 홀드 (라이브 트랙, 구역 기준). Redis + seats.status 동기화.
+     */
+    public Mono<Boolean> holdSeat(Long scheduleId, String zone, String seatNumber, Long userId) {
+        String holdKey = RedisKeyGenerator.holdKey(scheduleId, zone, seatNumber);
+        return redisTemplate.opsForValue()
+                .setIfAbsent(holdKey, userId.toString(), HOLD_TTL)
+                .flatMap(success -> {
+                    if (Boolean.TRUE.equals(success)) {
+                        log.info("좌석 홀드 성공: scheduleId={}, zone={}, seat={}, userId={}",
+                                scheduleId, zone, seatNumber, userId);
+                        return seatRepository.updateStatusByScheduleIdAndZoneAndSeatNumber(
+                                        SeatStatus.HELD.name(), scheduleId, zone, seatNumber)
+                                .thenReturn(true);
+                    }
+                    return Mono.just(false);
+                });
+    }
+
+    /**
+     * 홀드 해제. Redis 삭제 후 seats.status를 AVAILABLE로 복구.
+     */
+    public Mono<Boolean> releaseHold(Long scheduleId, String zone, String seatNumber) {
+        String holdKey = RedisKeyGenerator.holdKey(scheduleId, zone, seatNumber);
+        return redisTemplate.delete(holdKey)
+                .flatMap(deleted -> deleted > 0
+                        ? seatRepository.updateStatusByScheduleIdAndZoneAndSeatNumber(
+                                SeatStatus.AVAILABLE.name(), scheduleId, zone, seatNumber)
+                        .thenReturn(true)
+                        : Mono.just(false))
+                .doOnSuccess(success -> {
+                    if (Boolean.TRUE.equals(success)) {
+                        log.info("좌석 홀드 해제: scheduleId={}, zone={}, seat={}", scheduleId, zone, seatNumber);
+                    }
+                });
+    }
+
+    /**
+     * 홀드 소유자 확인
+     */
+    public Mono<Long> getHoldOwner(Long scheduleId, String zone, String seatNumber) {
+        String holdKey = RedisKeyGenerator.holdKey(scheduleId, zone, seatNumber);
+        return redisTemplate.opsForValue().get(holdKey)
+                .map(Long::parseLong);
+    }
+
+    /**
+     * 남은 홀드 시간 조회 (초 단위)
+     */
+    public Mono<Long> getRemainingHoldTime(Long scheduleId, String zone, String seatNumber) {
+        String holdKey = RedisKeyGenerator.holdKey(scheduleId, zone, seatNumber);
+        return redisTemplate.getExpire(holdKey)
+                .map(Duration::getSeconds);
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/seat/service/SeatPoolService.java
+++ b/src/main/java/com/opentraum/event/domain/seat/service/SeatPoolService.java
@@ -1,0 +1,158 @@
+package com.opentraum.event.domain.seat.service;
+
+import com.opentraum.event.domain.concert.entity.Zone;
+import com.opentraum.event.domain.concert.repository.ZoneRepository;
+import com.opentraum.event.domain.seat.dto.ZoneSeatAssignmentResponse;
+import com.opentraum.event.domain.seat.entity.Seat;
+import com.opentraum.event.domain.seat.repository.SeatRepository;
+import com.opentraum.event.global.util.RedisKeyGenerator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatPoolService {
+
+    private final ReactiveRedisTemplate<String, String> redisTemplate;
+    private final ZoneRepository zoneRepository;
+    private final SeatRepository seatRepository;
+
+    /**
+     * seats 테이블 기준으로 해당 회차 좌석 풀 초기화.
+     * 추가: 등급별 재고 카운터(stock:{scheduleId}:{grade})도 함께 초기화.
+     */
+    public Mono<Void> initializeSeatPools(Long scheduleId) {
+        return seatRepository.findByScheduleId(scheduleId)
+                .collectMultimap(Seat::getZone, Seat::getSeatNumber)
+                .flatMap(zoneToNumbers -> Flux.fromIterable(zoneToNumbers.entrySet())
+                        .flatMap(entry -> initializeSeatPoolWithNumbers(
+                                scheduleId,
+                                entry.getKey(),
+                                new ArrayList<>(entry.getValue())))
+                        .then())
+                .then(initializeStockCounters(scheduleId))
+                .doOnSuccess(v -> log.info("좌석 풀 + 재고 카운터 초기화 완료: scheduleId={}", scheduleId));
+    }
+
+    private Mono<Void> initializeStockCounters(Long scheduleId) {
+        return seatRepository.findSeatCountByScheduleIdGroupByGrade(scheduleId)
+                .flatMap(gradeSeatCount -> {
+                    String stockKey = RedisKeyGenerator.stockKey(scheduleId, gradeSeatCount.getGrade());
+                    String countValue = String.valueOf(gradeSeatCount.getCount());
+                    return redisTemplate.opsForValue().set(stockKey, countValue)
+                            .doOnSuccess(v -> log.info("재고 카운터 초기화: scheduleId={}, grade={}, stock={}",
+                                    scheduleId, gradeSeatCount.getGrade(), countValue));
+                })
+                .then();
+    }
+
+    public Mono<Void> initializeSeatPoolWithNumbers(Long scheduleId, String zone, List<String> seatNumbers) {
+        if (seatNumbers.isEmpty()) {
+            return Mono.empty();
+        }
+        String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
+        return redisTemplate.delete(poolKey)
+                .then(redisTemplate.opsForSet()
+                        .add(poolKey, seatNumbers.toArray(new String[0])))
+                .doOnSuccess(c -> log.info("좌석 풀 초기화: scheduleId={}, zone={}, count={}",
+                        scheduleId, zone, seatNumbers.size()))
+                .then();
+    }
+
+    public Mono<Long> getRemainingSeats(Long scheduleId, String zone) {
+        String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
+        return redisTemplate.opsForSet().size(poolKey);
+    }
+
+    public Mono<Long> getRemainingSeatsTotal(Long scheduleId) {
+        return zoneRepository.findByScheduleId(scheduleId)
+                .map(Zone::getZone)
+                .collectList()
+                .flatMap(zones -> {
+                    if (zones.isEmpty()) {
+                        return Mono.just(0L);
+                    }
+                    return redisTemplate.execute(connection ->
+                            Flux.fromIterable(zones)
+                                    .map(z -> ByteBuffer.wrap(RedisKeyGenerator.seatsKey(scheduleId, z)
+                                            .getBytes(StandardCharsets.UTF_8)))
+                                    .flatMap(key -> connection.setCommands().sCard(key))
+                                    .reduce(0L, Long::sum)
+                    ).next();
+                });
+    }
+
+    public Flux<String> getAvailableSeats(Long scheduleId, String zone) {
+        String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
+        return redisTemplate.opsForSet().members(poolKey);
+    }
+
+    public Mono<Boolean> selectSeat(Long scheduleId, String zone, String seatNumber) {
+        String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
+        return redisTemplate.opsForSet()
+                .remove(poolKey, seatNumber)
+                .map(removed -> removed > 0)
+                .doOnSuccess(success -> log.info("좌석 선택: scheduleId={}, zone={}, seat={}, success={}",
+                        scheduleId, zone, seatNumber, success));
+    }
+
+    public Mono<Boolean> returnSeat(Long scheduleId, String zone, String seatNumber) {
+        String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
+        return redisTemplate.opsForSet()
+                .add(poolKey, seatNumber)
+                .map(added -> added > 0)
+                .doOnSuccess(success -> log.info("좌석 반환: scheduleId={}, zone={}, seat={}",
+                        scheduleId, zone, seatNumber));
+    }
+
+    public Mono<ZoneSeatAssignmentResponse> popRandomSeat(Long scheduleId, String grade) {
+        return zoneRepository.findByScheduleIdAndGrade(scheduleId, grade)
+                .collectList()
+                .flatMap(zones -> {
+                    if (zones.isEmpty()) {
+                        return Mono.empty();
+                    }
+                    int idx = ThreadLocalRandom.current().nextInt(zones.size());
+                    String zone = zones.get(idx).getZone();
+                    String poolKey = RedisKeyGenerator.seatsKey(scheduleId, zone);
+
+                    return redisTemplate.opsForSet().pop(poolKey)
+                            .map(seatNumber -> {
+                                log.info("좌석 추출: scheduleId={}, grade={}, zone={}, seat={}",
+                                        scheduleId, grade, zone, seatNumber);
+                                return new ZoneSeatAssignmentResponse(zone, seatNumber);
+                            });
+                });
+    }
+
+    public Mono<List<ZoneSeatAssignmentResponse>> getAvailableSeatsForGrade(Long scheduleId, String grade) {
+        return zoneRepository.findByScheduleIdAndGrade(scheduleId, grade)
+                .flatMap(zone -> getAvailableSeats(scheduleId, zone.getZone())
+                        .map(seatNumber -> new ZoneSeatAssignmentResponse(zone.getZone(), seatNumber)))
+                .collectList();
+    }
+
+    public Mono<Long> getRemainingSeatsLottery(Long scheduleId, String grade) {
+        return seatRepository.countByScheduleIdAndGrade(scheduleId, grade)
+                .map(total -> total / 2)
+                .defaultIfEmpty(0L);
+    }
+
+    public Mono<Long> getRemainingSeatsForGrade(Long scheduleId, String grade) {
+        return zoneRepository.findByScheduleIdAndGrade(scheduleId, grade)
+                .flatMap(zone -> redisTemplate.opsForSet()
+                        .size(RedisKeyGenerator.seatsKey(scheduleId, zone.getZone())))
+                .reduce(0L, Long::sum);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,11 @@ spring:
       max-size: 20
       max-idle-time: 30m
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     producer:
@@ -21,6 +26,8 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       properties:
         spring.json.add.type.headers: false
+    consumer:
+      group-id: ${KAFKA_GROUP_ID:event-service-group}
 
   sql:
     init:
@@ -54,6 +61,11 @@ spring:
     url: r2dbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:opentraum_event}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
 
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,34 +1,72 @@
-CREATE TABLE IF NOT EXISTS events (
-    id              BIGSERIAL       PRIMARY KEY,
-    tenant_id       VARCHAR(64)     NOT NULL,
-    title           VARCHAR(255)    NOT NULL,
-    description     TEXT,
-    venue           VARCHAR(255)    NOT NULL,
-    start_date      TIMESTAMP       NOT NULL,
-    end_date        TIMESTAMP       NOT NULL,
-    total_seats     INTEGER         NOT NULL DEFAULT 0,
-    available_seats INTEGER         NOT NULL DEFAULT 0,
-    price           NUMERIC(12, 2)  NOT NULL DEFAULT 0,
-    status          VARCHAR(32)     NOT NULL DEFAULT 'DRAFT',
-    created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP
+-- =============================================
+-- OpenTraum Event Service Schema
+-- Migrated from FairTicket concert + seat domains
+-- =============================================
+
+-- 공연 (concerts) - tenantId 추가
+CREATE TABLE IF NOT EXISTS concerts (
+    id          BIGSERIAL       PRIMARY KEY,
+    title       VARCHAR(255)    NOT NULL,
+    artist      VARCHAR(255),
+    venue       VARCHAR(255)    NOT NULL,
+    tenant_id   VARCHAR(64)     NOT NULL,
+    created_at  TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP       DEFAULT CURRENT_TIMESTAMP
 );
 
-CREATE INDEX IF NOT EXISTS idx_events_tenant_id ON events (tenant_id);
-CREATE INDEX IF NOT EXISTS idx_events_status ON events (status);
-CREATE INDEX IF NOT EXISTS idx_events_tenant_status ON events (tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_concerts_tenant_id ON concerts (tenant_id);
 
+-- 공연 회차 (schedules)
+CREATE TABLE IF NOT EXISTS schedules (
+    id              BIGSERIAL       PRIMARY KEY,
+    concert_id      BIGINT          NOT NULL REFERENCES concerts(id),
+    date_time       TIMESTAMP       NOT NULL,
+    total_seats     INT             NOT NULL,
+    ticket_open_at  TIMESTAMP       NOT NULL,
+    ticket_close_at TIMESTAMP       NOT NULL,
+    status          VARCHAR(20)     NOT NULL DEFAULT 'UPCOMING',
+    created_at      TIMESTAMP       DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_schedules_concert ON schedules(concert_id);
+
+-- 등급 설정 (grades)
+CREATE TABLE IF NOT EXISTS grades (
+    id          BIGSERIAL   PRIMARY KEY,
+    schedule_id BIGINT      NOT NULL REFERENCES schedules(id),
+    grade       VARCHAR(10) NOT NULL,
+    price       INT         NOT NULL,
+    UNIQUE(schedule_id, grade)
+);
+
+CREATE INDEX IF NOT EXISTS idx_grades_schedule ON grades(schedule_id);
+
+-- 구역 설정 (zones)
+CREATE TABLE IF NOT EXISTS zones (
+    id          BIGSERIAL   PRIMARY KEY,
+    schedule_id BIGINT      NOT NULL REFERENCES schedules(id),
+    zone        VARCHAR(20) NOT NULL,
+    grade       VARCHAR(10) NOT NULL,
+    seat_count  INT         NOT NULL,
+    UNIQUE(schedule_id, zone)
+);
+
+CREATE INDEX IF NOT EXISTS idx_zones_schedule ON zones(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_zones_grade ON zones(schedule_id, grade);
+
+-- 좌석 (seats)
 CREATE TABLE IF NOT EXISTS seats (
-    id              BIGSERIAL       PRIMARY KEY,
-    event_id        BIGINT          NOT NULL REFERENCES events(id) ON DELETE CASCADE,
-    section         VARCHAR(64)     NOT NULL,
-    seat_row        VARCHAR(16)     NOT NULL,
-    seat_number     INTEGER         NOT NULL,
-    grade           VARCHAR(32)     NOT NULL,
-    price           NUMERIC(12, 2)  NOT NULL DEFAULT 0,
-    status          VARCHAR(32)     NOT NULL DEFAULT 'AVAILABLE'
+    id          BIGSERIAL       PRIMARY KEY,
+    schedule_id BIGINT          NOT NULL REFERENCES schedules(id),
+    grade       VARCHAR(10)     NOT NULL,
+    zone        VARCHAR(20)     NOT NULL,
+    seat_number VARCHAR(20)     NOT NULL,
+    price       INT             NOT NULL,
+    status      VARCHAR(20)     NOT NULL DEFAULT 'AVAILABLE',
+    created_at  TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(schedule_id, zone, seat_number)
 );
 
-CREATE INDEX IF NOT EXISTS idx_seats_event_id ON seats (event_id);
-CREATE INDEX IF NOT EXISTS idx_seats_event_status ON seats (event_id, status);
-CREATE INDEX IF NOT EXISTS idx_seats_event_grade ON seats (event_id, grade);
+CREATE INDEX IF NOT EXISTS idx_seats_schedule ON seats(schedule_id);
+CREATE INDEX IF NOT EXISTS idx_seats_schedule_zone ON seats(schedule_id, zone);
+CREATE INDEX IF NOT EXISTS idx_seats_status ON seats(status);


### PR DESCRIPTION
## 개요
FairTicket 모놀리스의 Concert/Seat 도메인을 event-service MSA로 마이그레이션합니다.
Closes #3

## 변경 사항
- Concert/Schedule/Grade/Zone 엔티티 + 리포지토리 + 서비스
- Seat 엔티티 + SeatRepository (@Query 포함)
- ConcertService: 공연 목록/상세 (등급별 잔여석 집계)
- ScheduleService: 스케줄 검증, 등급/구역 조회
- SeatPoolService: Redis Set 기반 좌석 풀 (초기화/선택/반환/추출)
- SeatHoldService: Redis 기반 좌석 홀드 (TTL 관리)
- ConcertController, ScheduleController, SeatPoolController
- 전체 DTO 마이그레이션 (ConcertResponse, GradeDetailResponse 등)
- schema.sql (concerts, schedules, grades, zones, seats DDL)

## 테스트 계획
- [ ] 공연 목록/상세 API 동작 확인
- [ ] 스케줄별 등급/구역 조회 확인
- [ ] Redis 좌석 풀 초기화/선택 동작 확인