### PR TITLE
feat: #7 TrackPolicy enum 추가 + Schedule 엔티티 trackPolicy 필드

### DIFF
--- a/src/main/java/com/opentraum/event/domain/concert/entity/Schedule.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/Schedule.java
@@ -29,5 +29,7 @@ public class Schedule {
 
     private String status;
 
+    private String trackPolicy;
+
     private LocalDateTime createdAt;
 }

--- a/src/main/java/com/opentraum/event/domain/concert/entity/TrackPolicy.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/TrackPolicy.java
@@ -1,0 +1,7 @@
+package com.opentraum.event.domain.concert.entity;
+
+public enum TrackPolicy {
+    LOTTERY_ONLY,
+    LIVE_ONLY,
+    DUAL_TRACK
+}

--- a/src/main/java/com/opentraum/event/domain/internal/dto/ScheduleInfo.java
+++ b/src/main/java/com/opentraum/event/domain/internal/dto/ScheduleInfo.java
@@ -13,6 +13,7 @@ public class ScheduleInfo {
     private Long concertId;
     private LocalDateTime ticketOpenAt;
     private String status;
+    private String trackPolicy;
 
     public static ScheduleInfo from(Schedule schedule) {
         return ScheduleInfo.builder()
@@ -20,6 +21,7 @@ public class ScheduleInfo {
                 .concertId(schedule.getConcertId())
                 .ticketOpenAt(schedule.getTicketOpenAt())
                 .status(schedule.getStatus())
+                .trackPolicy(schedule.getTrackPolicy())
                 .build();
     }
 }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS schedules (
     ticket_open_at  TIMESTAMP       NOT NULL,
     ticket_close_at TIMESTAMP       NOT NULL,
     status          VARCHAR(20)     NOT NULL DEFAULT 'UPCOMING',
+    track_policy    VARCHAR(20)     NOT NULL DEFAULT 'DUAL_TRACK',
     created_at      TIMESTAMP       DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## 개요
배정 방식 커스터마이징을 위해 TrackPolicy enum과 Schedule trackPolicy 필드를 추가합니다.

closes #7

## 변경 사항 (4 files changed, +12 / -0)

### 신규
| 파일 | 역할 |
|---|---|
| `TrackPolicy.java` | `LOTTERY_ONLY`, `LIVE_ONLY`, `DUAL_TRACK` enum |

### 수정
| 파일 | 변경 내용 |
|---|---|
| `Schedule.java` | `trackPolicy` 필드 추가 |
| `ScheduleInfo.java` | `trackPolicy` 필드 추가 + `from()` 매핑 |
| `schema.sql` | `schedules` 테이블에 `track_policy VARCHAR(20) DEFAULT 'DUAL_TRACK'` 컬럼 추가 |

## 컴파일 검증
`./gradlew compileJava` ✅ BUILD SUCCESSFUL