### PR TITLE
feat: #11 AI 이벤트 생성 (OpenAI function calling)

### DIFF
--- a/src/main/java/com/opentraum/event/config/OpenAiProperties.java
+++ b/src/main/java/com/opentraum/event/config/OpenAiProperties.java
@@ -1,0 +1,17 @@
+package com.opentraum.event.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "openai")
+public class OpenAiProperties {
+
+    private String apiKey;
+    private String model = "gpt-4o-mini";
+    private String baseUrl = "https://api.openai.com/v1";
+}

--- a/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
+++ b/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
@@ -1,0 +1,31 @@
+package com.opentraum.event.domain.admin.controller;
+
+import com.opentraum.event.domain.admin.dto.AiGenerateRequest;
+import com.opentraum.event.domain.admin.dto.AiGenerateResponse;
+import com.opentraum.event.domain.admin.service.AiEventGenerateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@Tag(name = "Admin - Events", description = "어드민 이벤트 관리 API")
+@RestController
+@RequestMapping("/api/v1/admin/events")
+@RequiredArgsConstructor
+public class AdminEventController {
+
+    private final AiEventGenerateService aiEventGenerateService;
+
+    @Operation(summary = "AI 이벤트 구성 자동 생성")
+    @PostMapping("/ai-generate")
+    public Mono<ResponseEntity<AiGenerateResponse>> aiGenerate(@Valid @RequestBody AiGenerateRequest request) {
+        return aiEventGenerateService.generate(request.getPrompt())
+                .map(ResponseEntity::ok);
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/admin/dto/AiGenerateRequest.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/AiGenerateRequest.java
@@ -1,0 +1,13 @@
+package com.opentraum.event.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AiGenerateRequest {
+
+    @NotBlank(message = "프롬프트를 입력해주세요")
+    private String prompt;
+}

--- a/src/main/java/com/opentraum/event/domain/admin/dto/AiGenerateResponse.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/AiGenerateResponse.java
@@ -1,0 +1,41 @@
+package com.opentraum.event.domain.admin.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiGenerateResponse {
+
+    private String title;
+    private String artist;
+    private String venue;
+    private String dateTime;
+    private Integer totalSeats;
+    private String trackPolicy;
+    private List<GradeConfig> grades;
+    private List<ZoneConfig> zones;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GradeConfig {
+        private String grade;
+        private Integer price;
+        private Integer seatCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ZoneConfig {
+        private String zone;
+        private String grade;
+        private Integer seatCount;
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/admin/service/AiEventGenerateService.java
+++ b/src/main/java/com/opentraum/event/domain/admin/service/AiEventGenerateService.java
@@ -1,0 +1,192 @@
+package com.opentraum.event.domain.admin.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opentraum.event.config.OpenAiProperties;
+import com.opentraum.event.domain.admin.dto.AiGenerateResponse;
+import com.opentraum.event.global.exception.BusinessException;
+import com.opentraum.event.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class AiEventGenerateService {
+
+    private final WebClient webClient;
+    private final OpenAiProperties openAiProperties;
+    private final ObjectMapper objectMapper;
+
+    public AiEventGenerateService(OpenAiProperties openAiProperties, ObjectMapper objectMapper) {
+        this.openAiProperties = openAiProperties;
+        this.objectMapper = objectMapper;
+        this.webClient = WebClient.builder()
+                .baseUrl(openAiProperties.getBaseUrl())
+                .defaultHeader("Content-Type", "application/json")
+                .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(1024 * 1024))
+                .build();
+    }
+
+    public Mono<AiGenerateResponse> generate(String prompt) {
+        Map<String, Object> requestBody = buildRequestBody(prompt);
+
+        return webClient.post()
+                .uri("/chat/completions")
+                .header("Authorization", "Bearer " + openAiProperties.getApiKey())
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .map(this::parseResponse)
+                .doOnSuccess(r -> log.info("AI 이벤트 생성 완료: title={}, venue={}, seats={}",
+                        r.getTitle(), r.getVenue(), r.getTotalSeats()))
+                .onErrorMap(e -> !(e instanceof BusinessException),
+                        e -> {
+                            log.error("OpenAI API 호출 실패", e);
+                            return new BusinessException(ErrorCode.INTERNAL_ERROR);
+                        });
+    }
+
+    private Map<String, Object> buildRequestBody(String prompt) {
+        return Map.of(
+                "model", openAiProperties.getModel(),
+                "messages", List.of(
+                        Map.of("role", "system", "content", SYSTEM_PROMPT),
+                        Map.of("role", "user", "content", prompt)
+                ),
+                "tools", List.of(Map.of(
+                        "type", "function",
+                        "function", FUNCTION_SCHEMA
+                )),
+                "tool_choice", Map.of(
+                        "type", "function",
+                        "function", Map.of("name", "generate_event_config")
+                )
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private AiGenerateResponse parseResponse(Map<String, Object> response) {
+        try {
+            List<Map<String, Object>> choices = (List<Map<String, Object>>) response.get("choices");
+            Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
+            List<Map<String, Object>> toolCalls = (List<Map<String, Object>>) message.get("tool_calls");
+            Map<String, Object> function = (Map<String, Object>) toolCalls.get(0).get("function");
+            String arguments = (String) function.get("arguments");
+
+            Map<String, Object> args = objectMapper.readValue(arguments, new TypeReference<>() {});
+
+            List<AiGenerateResponse.GradeConfig> grades = ((List<Map<String, Object>>) args.get("grades")).stream()
+                    .map(g -> AiGenerateResponse.GradeConfig.builder()
+                            .grade((String) g.get("grade"))
+                            .price(((Number) g.get("price")).intValue())
+                            .seatCount(((Number) g.get("seatCount")).intValue())
+                            .build())
+                    .toList();
+
+            List<AiGenerateResponse.ZoneConfig> zones = ((List<Map<String, Object>>) args.get("zones")).stream()
+                    .map(z -> AiGenerateResponse.ZoneConfig.builder()
+                            .zone((String) z.get("zone"))
+                            .grade((String) z.get("grade"))
+                            .seatCount(((Number) z.get("seatCount")).intValue())
+                            .build())
+                    .toList();
+
+            return AiGenerateResponse.builder()
+                    .title((String) args.get("title"))
+                    .artist((String) args.get("artist"))
+                    .venue((String) args.get("venue"))
+                    .dateTime((String) args.get("dateTime"))
+                    .totalSeats(((Number) args.get("totalSeats")).intValue())
+                    .trackPolicy((String) args.get("trackPolicy"))
+                    .grades(grades)
+                    .zones(zones)
+                    .build();
+        } catch (Exception e) {
+            log.error("OpenAI 응답 파싱 실패: {}", response, e);
+            throw new BusinessException(ErrorCode.INTERNAL_ERROR);
+        }
+    }
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 티켓팅 플랫폼 OpenTraum의 이벤트 구성 전문가입니다.
+            사용자의 자연어 입력을 분석하여 공연/이벤트 구성을 생성합니다.
+
+            ## 규칙
+            1. trackPolicy 추천 기준:
+               - 100석 이하: LIVE_ONLY (소규모, 대기열 불필요)
+               - 100~1000석: LIVE_ONLY 또는 LOTTERY_ONLY (상황에 따라 판단)
+               - 1000석 이상: DUAL_TRACK (트래픽 분산 필요)
+
+            2. 등급(grade) 구성:
+               - 대규모: VIP / R / S / A 등 다양한 등급
+               - 소규모: 전석 단일 등급도 가능
+               - 가격은 한국 원화 기준으로 현실적으로 설정
+
+            3. 구역(zone) 구성:
+               - 각 구역은 하나의 등급에 매핑
+               - 구역별 좌석 수 합 = totalSeats
+               - 등급별 좌석 수 합 = 해당 등급의 전체 구역 좌석 수 합
+
+            4. 날짜가 명시되지 않으면 적절한 미래 날짜를 설정 (ISO-8601 형식)
+            5. 아티스트가 명시되지 않으면 null로 설정
+
+            ## 공연장 프리셋 참고
+            - 올림픽홀: 2,400석 (1층 1200, 2층 1200)
+            - 블루스퀘어: 1,766석 (1층 900, 2층 866)
+            - 예스24 라이브홀: 2,000석 (스탠딩 2000)
+            - 소규모 공연장: 300석 (전석 300)
+            - 세종문화회관 대극장: 3,022석 (1층 1500, 2층 800, 3층 722)
+            """;
+
+    private static final Map<String, Object> FUNCTION_SCHEMA = Map.of(
+            "name", "generate_event_config",
+            "description", "공연/이벤트의 전체 구성을 생성합니다",
+            "parameters", Map.of(
+                    "type", "object",
+                    "properties", Map.ofEntries(
+                            Map.entry("title", Map.of("type", "string", "description", "공연 제목")),
+                            Map.entry("artist", Map.of("type", "string", "description", "아티스트/출연자 이름 (없으면 null)")),
+                            Map.entry("venue", Map.of("type", "string", "description", "공연장 이름")),
+                            Map.entry("dateTime", Map.of("type", "string", "description", "공연 날짜/시간 (ISO-8601)")),
+                            Map.entry("totalSeats", Map.of("type", "integer", "description", "총 좌석 수")),
+                            Map.entry("trackPolicy", Map.of(
+                                    "type", "string",
+                                    "enum", List.of("LOTTERY_ONLY", "LIVE_ONLY", "DUAL_TRACK"),
+                                    "description", "배정 방식 (100석 이하: LIVE_ONLY, 100~1000: LIVE_ONLY/LOTTERY_ONLY, 1000+: DUAL_TRACK)"
+                            )),
+                            Map.entry("grades", Map.of(
+                                    "type", "array",
+                                    "description", "등급 구성 목록",
+                                    "items", Map.of(
+                                            "type", "object",
+                                            "properties", Map.of(
+                                                    "grade", Map.of("type", "string", "description", "등급명 (예: VIP, R, S, A)"),
+                                                    "price", Map.of("type", "integer", "description", "가격 (원)"),
+                                                    "seatCount", Map.of("type", "integer", "description", "해당 등급 좌석 수")
+                                            ),
+                                            "required", List.of("grade", "price", "seatCount")
+                                    )
+                            )),
+                            Map.entry("zones", Map.of(
+                                    "type", "array",
+                                    "description", "구역 구성 목록",
+                                    "items", Map.of(
+                                            "type", "object",
+                                            "properties", Map.of(
+                                                    "zone", Map.of("type", "string", "description", "구역명 (예: 1층, 2층, 스탠딩)"),
+                                                    "grade", Map.of("type", "string", "description", "해당 구역의 등급"),
+                                                    "seatCount", Map.of("type", "integer", "description", "구역 좌석 수")
+                                            ),
+                                            "required", List.of("zone", "grade", "seatCount")
+                                    )
+                            ))
+                    ),
+                    "required", List.of("title", "venue", "totalSeats", "trackPolicy", "grades", "zones")
+            )
+    );
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,10 @@ spring:
     init:
       mode: always
 
+openai:
+  api-key: ${OPENAI_API_KEY:}
+  model: ${OPENAI_MODEL:gpt-4o-mini}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
## 개요
자연어 입력 → OpenAI function calling → 구조화된 이벤트 구성 JSON을 반환합니다.
어드민이 "3월 올림픽홀 콘서트 1000석" 같은 자연어를 입력하면 AI가 등급/가격/구역/배정방식을 자동 생성합니다.

closes #11

## 변경 사항 (6 files changed, +298 / -0)

### 신규
| 파일 | 역할 |
|---|---|
| `OpenAiProperties.java` | API 키, 모델명 설정 (`OPENAI_API_KEY` 환경변수) |
| `AiGenerateRequest.java` | 요청 DTO (prompt 필드) |
| `AiGenerateResponse.java` | 응답 DTO (title, artist, venue, dateTime, totalSeats, trackPolicy, grades[], zones[]) |
| `AiEventGenerateService.java` | WebClient → OpenAI Chat Completions API (function calling) |
| `AdminEventController.java` | `POST /api/v1/admin/events/ai-generate` |

### 수정
| 파일 | 변경 내용 |
|---|---|
| `application.yml` | `openai.api-key`, `openai.model` 설정 추가 |

## AI 추천 기준 (시스템 프롬프트)
| 좌석 수 | trackPolicy |
|---|---|
| 100석 이하 | LIVE_ONLY |
| 100~1000석 | LIVE_ONLY / LOTTERY_ONLY |
| 1000석 이상 | DUAL_TRACK |

## 기술 구현
- Spring WebClient → OpenAI `/v1/chat/completions` 호출
- `tools` 파라미터 (function calling) → `generate_event_config` 함수 강제 호출
- 시스템 프롬프트에 공연장 프리셋 5개 포함 (올림픽홀, 블루스퀘어 등)
- 모델: `gpt-4o-mini` (환경변수로 변경 가능)

## 컴파일 검증
`./gradlew compileJava` ✅ BUILD SUCCESSFUL