### PR TITLE
feat: #13 어드민 이벤트 CRUD + 판매 현황 API

### DIFF
--- a/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
+++ b/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
@@ -1,18 +1,17 @@
 package com.opentraum.event.domain.admin.controller;
 
-import com.opentraum.event.domain.admin.dto.AiGenerateRequest;
-import com.opentraum.event.domain.admin.dto.AiGenerateResponse;
+import com.opentraum.event.domain.admin.dto.*;
+import com.opentraum.event.domain.admin.service.AdminEventService;
 import com.opentraum.event.domain.admin.service.AiEventGenerateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @Tag(name = "Admin - Events", description = "어드민 이벤트 관리 API")
 @RestController
@@ -21,11 +20,57 @@ import reactor.core.publisher.Mono;
 public class AdminEventController {
 
     private final AiEventGenerateService aiEventGenerateService;
+    private final AdminEventService adminEventService;
 
     @Operation(summary = "AI 이벤트 구성 자동 생성")
     @PostMapping("/ai-generate")
     public Mono<ResponseEntity<AiGenerateResponse>> aiGenerate(@Valid @RequestBody AiGenerateRequest request) {
         return aiEventGenerateService.generate(request.getPrompt())
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "이벤트 생성")
+    @PostMapping
+    public Mono<ResponseEntity<AdminEventResponse>> createEvent(@Valid @RequestBody AdminEventCreateRequest request) {
+        return adminEventService.createEvent(request)
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "이벤트 목록 조회")
+    @GetMapping
+    public Mono<ResponseEntity<List<AdminEventResponse>>> listEvents() {
+        return adminEventService.listEvents()
+                .collectList()
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "이벤트 상세 조회")
+    @GetMapping("/{scheduleId}")
+    public Mono<ResponseEntity<AdminEventResponse>> getEvent(@PathVariable Long scheduleId) {
+        return adminEventService.getEvent(scheduleId)
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "이벤트 수정")
+    @PutMapping("/{scheduleId}")
+    public Mono<ResponseEntity<AdminEventResponse>> updateEvent(
+            @PathVariable Long scheduleId,
+            @Valid @RequestBody AdminEventCreateRequest request) {
+        return adminEventService.updateEvent(scheduleId, request)
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "이벤트 삭제")
+    @DeleteMapping("/{scheduleId}")
+    public Mono<ResponseEntity<Void>> deleteEvent(@PathVariable Long scheduleId) {
+        return adminEventService.deleteEvent(scheduleId)
+                .then(Mono.just(ResponseEntity.noContent().<Void>build()));
+    }
+
+    @Operation(summary = "판매 현황 대시보드")
+    @GetMapping("/{scheduleId}/dashboard")
+    public Mono<ResponseEntity<AdminDashboardResponse>> getDashboard(@PathVariable Long scheduleId) {
+        return adminEventService.getDashboard(scheduleId)
                 .map(ResponseEntity::ok);
     }
 }

--- a/src/main/java/com/opentraum/event/domain/admin/dto/AdminDashboardResponse.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/AdminDashboardResponse.java
@@ -1,0 +1,31 @@
+package com.opentraum.event.domain.admin.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminDashboardResponse {
+
+    private Long scheduleId;
+    private String title;
+    private String status;
+    private Integer totalSeats;
+    private Long soldSeats;
+    private Long availableSeats;
+    private List<GradeStat> gradeStats;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GradeStat {
+        private String grade;
+        private Long totalSeats;
+        private Long soldSeats;
+        private Long availableSeats;
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/admin/dto/AdminEventCreateRequest.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/AdminEventCreateRequest.java
@@ -1,0 +1,56 @@
+package com.opentraum.event.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class AdminEventCreateRequest {
+
+    @NotBlank
+    private String title;
+    private String artist;
+    @NotBlank
+    private String venue;
+    @NotNull
+    private LocalDateTime dateTime;
+    @NotNull
+    @Positive
+    private Integer totalSeats;
+    @NotNull
+    private LocalDateTime ticketOpenAt;
+    @NotNull
+    private LocalDateTime ticketCloseAt;
+    @NotBlank
+    private String trackPolicy;
+    @NotBlank
+    private String tenantId;
+
+    @NotEmpty
+    private List<GradeInput> grades;
+    @NotEmpty
+    private List<ZoneInput> zones;
+
+    @Getter
+    @NoArgsConstructor
+    public static class GradeInput {
+        private String grade;
+        private Integer price;
+        private Integer seatCount;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class ZoneInput {
+        private String zone;
+        private String grade;
+        private Integer seatCount;
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/admin/dto/AdminEventResponse.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/AdminEventResponse.java
@@ -1,0 +1,47 @@
+package com.opentraum.event.domain.admin.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminEventResponse {
+
+    private Long concertId;
+    private Long scheduleId;
+    private String title;
+    private String artist;
+    private String venue;
+    private String tenantId;
+    private LocalDateTime dateTime;
+    private Integer totalSeats;
+    private LocalDateTime ticketOpenAt;
+    private LocalDateTime ticketCloseAt;
+    private String trackPolicy;
+    private String status;
+    private List<GradeInfo> grades;
+    private List<ZoneInfo> zones;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GradeInfo {
+        private String grade;
+        private Integer price;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ZoneInfo {
+        private String zone;
+        private String grade;
+        private Integer seatCount;
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/admin/service/AdminEventService.java
+++ b/src/main/java/com/opentraum/event/domain/admin/service/AdminEventService.java
@@ -1,0 +1,246 @@
+package com.opentraum.event.domain.admin.service;
+
+import com.opentraum.event.domain.admin.dto.*;
+import com.opentraum.event.domain.concert.entity.*;
+import com.opentraum.event.domain.concert.repository.*;
+import com.opentraum.event.domain.seat.entity.Seat;
+import com.opentraum.event.domain.seat.entity.SeatStatus;
+import com.opentraum.event.domain.seat.repository.SeatRepository;
+import com.opentraum.event.global.exception.BusinessException;
+import com.opentraum.event.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminEventService {
+
+    private final ConcertRepository concertRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final GradeRepository gradeRepository;
+    private final ZoneRepository zoneRepository;
+    private final SeatRepository seatRepository;
+
+    public Mono<AdminEventResponse> createEvent(AdminEventCreateRequest request) {
+        Concert concert = Concert.builder()
+                .title(request.getTitle())
+                .artist(request.getArtist())
+                .venue(request.getVenue())
+                .tenantId(request.getTenantId())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+
+        return concertRepository.save(concert)
+                .flatMap(savedConcert -> {
+                    Schedule schedule = Schedule.builder()
+                            .concertId(savedConcert.getId())
+                            .dateTime(request.getDateTime())
+                            .totalSeats(request.getTotalSeats())
+                            .ticketOpenAt(request.getTicketOpenAt())
+                            .ticketCloseAt(request.getTicketCloseAt())
+                            .trackPolicy(request.getTrackPolicy())
+                            .status(ScheduleStatus.UPCOMING.name())
+                            .createdAt(LocalDateTime.now())
+                            .build();
+
+                    return scheduleRepository.save(schedule)
+                            .flatMap(savedSchedule -> {
+                                // grade name → price 매핑
+                                Map<String, Integer> gradePriceMap = request.getGrades().stream()
+                                        .collect(Collectors.toMap(
+                                                AdminEventCreateRequest.GradeInput::getGrade,
+                                                AdminEventCreateRequest.GradeInput::getPrice));
+
+                                // Grade 저장
+                                Mono<List<Grade>> gradesMono = Flux.fromIterable(request.getGrades())
+                                        .map(g -> Grade.builder()
+                                                .scheduleId(savedSchedule.getId())
+                                                .grade(g.getGrade())
+                                                .price(g.getPrice())
+                                                .build())
+                                        .flatMap(gradeRepository::save)
+                                        .collectList();
+
+                                // Zone 저장
+                                Mono<List<Zone>> zonesMono = Flux.fromIterable(request.getZones())
+                                        .map(z -> Zone.builder()
+                                                .scheduleId(savedSchedule.getId())
+                                                .zone(z.getZone())
+                                                .grade(z.getGrade())
+                                                .seatCount(z.getSeatCount())
+                                                .build())
+                                        .flatMap(zoneRepository::save)
+                                        .collectList();
+
+                                // Seat 생성
+                                Mono<Void> seatsMono = Flux.fromIterable(request.getZones())
+                                        .flatMap(z -> {
+                                            Integer price = gradePriceMap.getOrDefault(z.getGrade(), 0);
+                                            List<Seat> seats = new ArrayList<>();
+                                            for (int i = 1; i <= z.getSeatCount(); i++) {
+                                                seats.add(Seat.builder()
+                                                        .scheduleId(savedSchedule.getId())
+                                                        .grade(z.getGrade())
+                                                        .zone(z.getZone())
+                                                        .seatNumber(String.valueOf(i))
+                                                        .price(price)
+                                                        .status(SeatStatus.AVAILABLE.name())
+                                                        .createdAt(LocalDateTime.now())
+                                                        .build());
+                                            }
+                                            return seatRepository.saveAll(seats).then();
+                                        })
+                                        .then();
+
+                                return Mono.zip(gradesMono, zonesMono, seatsMono.thenReturn(true))
+                                        .map(tuple -> buildResponse(savedConcert, savedSchedule, tuple.getT1(), tuple.getT2()));
+                            });
+                })
+                .doOnSuccess(r -> log.info("이벤트 생성 완료: concertId={}, scheduleId={}", r.getConcertId(), r.getScheduleId()));
+    }
+
+    public Mono<AdminEventResponse> getEvent(Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
+                .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .flatMap(concert -> Mono.zip(
+                                gradeRepository.findByScheduleId(scheduleId).collectList(),
+                                zoneRepository.findByScheduleId(scheduleId).collectList()
+                        ).map(tuple -> buildResponse(concert, schedule, tuple.getT1(), tuple.getT2()))));
+    }
+
+    public Flux<AdminEventResponse> listEvents() {
+        return scheduleRepository.findAll()
+                .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .map(concert -> AdminEventResponse.builder()
+                                .concertId(concert.getId())
+                                .scheduleId(schedule.getId())
+                                .title(concert.getTitle())
+                                .artist(concert.getArtist())
+                                .venue(concert.getVenue())
+                                .tenantId(concert.getTenantId())
+                                .dateTime(schedule.getDateTime())
+                                .totalSeats(schedule.getTotalSeats())
+                                .ticketOpenAt(schedule.getTicketOpenAt())
+                                .ticketCloseAt(schedule.getTicketCloseAt())
+                                .trackPolicy(schedule.getTrackPolicy())
+                                .status(schedule.getStatus())
+                                .build()));
+    }
+
+    public Mono<AdminEventResponse> updateEvent(Long scheduleId, AdminEventCreateRequest request) {
+        return scheduleRepository.findById(scheduleId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
+                .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .flatMap(concert -> {
+                            concert.setTitle(request.getTitle());
+                            concert.setArtist(request.getArtist());
+                            concert.setVenue(request.getVenue());
+                            concert.setUpdatedAt(LocalDateTime.now());
+
+                            schedule.setDateTime(request.getDateTime());
+                            schedule.setTotalSeats(request.getTotalSeats());
+                            schedule.setTicketOpenAt(request.getTicketOpenAt());
+                            schedule.setTicketCloseAt(request.getTicketCloseAt());
+                            schedule.setTrackPolicy(request.getTrackPolicy());
+
+                            return Mono.zip(
+                                    concertRepository.save(concert),
+                                    scheduleRepository.save(schedule)
+                            );
+                        })
+                        .flatMap(tuple -> getEvent(scheduleId)));
+    }
+
+    public Mono<Void> deleteEvent(Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
+                .flatMap(schedule -> seatRepository.deleteByScheduleId(scheduleId)
+                        .then(zoneRepository.deleteByScheduleId(scheduleId))
+                        .then(gradeRepository.deleteByScheduleId(scheduleId))
+                        .then(scheduleRepository.deleteById(scheduleId))
+                        .then(concertRepository.deleteById(schedule.getConcertId())))
+                .doOnSuccess(v -> log.info("이벤트 삭제 완료: scheduleId={}", scheduleId));
+    }
+
+    public Mono<AdminDashboardResponse> getDashboard(Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
+                .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .flatMap(concert -> Mono.zip(
+                                seatRepository.findSeatCountByScheduleIdGroupByGrade(scheduleId).collectList(),
+                                seatRepository.findSoldSeatCountByScheduleIdGroupByGrade(scheduleId).collectList()
+                        ).map(tuple -> {
+                            Map<String, Long> totalByGrade = tuple.getT1().stream()
+                                    .collect(Collectors.toMap(g -> g.getGrade(), g -> g.getCount()));
+                            Map<String, Long> soldByGrade = tuple.getT2().stream()
+                                    .collect(Collectors.toMap(g -> g.getGrade(), g -> g.getCount()));
+
+                            long totalSold = soldByGrade.values().stream().mapToLong(Long::longValue).sum();
+                            long totalAvailable = schedule.getTotalSeats() - totalSold;
+
+                            List<AdminDashboardResponse.GradeStat> gradeStats = totalByGrade.entrySet().stream()
+                                    .map(e -> {
+                                        long sold = soldByGrade.getOrDefault(e.getKey(), 0L);
+                                        return AdminDashboardResponse.GradeStat.builder()
+                                                .grade(e.getKey())
+                                                .totalSeats(e.getValue())
+                                                .soldSeats(sold)
+                                                .availableSeats(e.getValue() - sold)
+                                                .build();
+                                    })
+                                    .toList();
+
+                            return AdminDashboardResponse.builder()
+                                    .scheduleId(scheduleId)
+                                    .title(concert.getTitle())
+                                    .status(schedule.getStatus())
+                                    .totalSeats(schedule.getTotalSeats())
+                                    .soldSeats(totalSold)
+                                    .availableSeats(totalAvailable)
+                                    .gradeStats(gradeStats)
+                                    .build();
+                        })));
+    }
+
+    private AdminEventResponse buildResponse(Concert concert, Schedule schedule, List<Grade> grades, List<Zone> zones) {
+        return AdminEventResponse.builder()
+                .concertId(concert.getId())
+                .scheduleId(schedule.getId())
+                .title(concert.getTitle())
+                .artist(concert.getArtist())
+                .venue(concert.getVenue())
+                .tenantId(concert.getTenantId())
+                .dateTime(schedule.getDateTime())
+                .totalSeats(schedule.getTotalSeats())
+                .ticketOpenAt(schedule.getTicketOpenAt())
+                .ticketCloseAt(schedule.getTicketCloseAt())
+                .trackPolicy(schedule.getTrackPolicy())
+                .status(schedule.getStatus())
+                .grades(grades.stream()
+                        .map(g -> AdminEventResponse.GradeInfo.builder()
+                                .grade(g.getGrade())
+                                .price(g.getPrice())
+                                .build())
+                        .toList())
+                .zones(zones.stream()
+                        .map(z -> AdminEventResponse.ZoneInfo.builder()
+                                .zone(z.getZone())
+                                .grade(z.getGrade())
+                                .seatCount(z.getSeatCount())
+                                .build())
+                        .toList())
+                .build();
+    }
+}

--- a/src/main/java/com/opentraum/event/domain/concert/repository/GradeRepository.java
+++ b/src/main/java/com/opentraum/event/domain/concert/repository/GradeRepository.java
@@ -3,8 +3,11 @@ package com.opentraum.event.domain.concert.repository;
 import com.opentraum.event.domain.concert.entity.Grade;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 public interface GradeRepository extends ReactiveCrudRepository<Grade, Long> {
 
     Flux<Grade> findByScheduleId(Long scheduleId);
+
+    Mono<Void> deleteByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/opentraum/event/domain/concert/repository/ScheduleRepository.java
+++ b/src/main/java/com/opentraum/event/domain/concert/repository/ScheduleRepository.java
@@ -3,6 +3,7 @@ package com.opentraum.event.domain.concert.repository;
 import com.opentraum.event.domain.concert.entity.Schedule;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.time.LocalDateTime;
 
@@ -13,4 +14,6 @@ public interface ScheduleRepository extends ReactiveCrudRepository<Schedule, Lon
     Flux<Schedule> findByTicketOpenAtLessThanEqual(LocalDateTime time);
 
     Flux<Schedule> findByTicketOpenAtLessThanEqualAndStatusNot(LocalDateTime time, String status);
+
+    Mono<Void> deleteByConcertId(Long concertId);
 }

--- a/src/main/java/com/opentraum/event/domain/concert/repository/ZoneRepository.java
+++ b/src/main/java/com/opentraum/event/domain/concert/repository/ZoneRepository.java
@@ -14,4 +14,6 @@ public interface ZoneRepository extends ReactiveCrudRepository<Zone, Long> {
     Mono<Zone> findByScheduleIdAndZone(Long scheduleId, String zone);
 
     Mono<Zone> findByScheduleIdAndGradeAndZone(Long scheduleId, String grade, String zone);
+
+    Mono<Void> deleteByScheduleId(Long scheduleId);
 }

--- a/src/main/java/com/opentraum/event/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/opentraum/event/domain/seat/repository/SeatRepository.java
@@ -36,4 +36,9 @@ public interface SeatRepository extends ReactiveCrudRepository<Seat, Long> {
 
     @Query("SELECT grade, COUNT(*) as count FROM seats WHERE schedule_id = :scheduleId AND status = 'AVAILABLE' GROUP BY grade")
     Flux<GradeSeatCount> findAvailableSeatCountByScheduleIdGroupByGrade(@Param("scheduleId") Long scheduleId);
+
+    @Query("SELECT grade, COUNT(*) as count FROM seats WHERE schedule_id = :scheduleId AND status = 'SOLD' GROUP BY grade")
+    Flux<GradeSeatCount> findSoldSeatCountByScheduleIdGroupByGrade(@Param("scheduleId") Long scheduleId);
+
+    Mono<Void> deleteByScheduleId(Long scheduleId);
 }


### PR DESCRIPTION
## 개요
어드민이 이벤트를 생성/조회/수정/삭제하고 판매 현황을 확인할 수 있는 API를 추가합니다.

closes #13

## 변경 사항 (9 files changed, +444 / -6)

### 신규
| 파일 | 역할 |
|---|---|
| `AdminEventCreateRequest.java` | 이벤트 생성 요청 DTO (title, venue, dateTime, grades[], zones[] 등) |
| `AdminEventResponse.java` | 이벤트 응답 DTO (concert + schedule + grades + zones) |
| `AdminDashboardResponse.java` | 판매 현황 응답 DTO (등급별 total/sold/available) |
| `AdminEventService.java` | CRUD + Dashboard 비즈니스 로직 |

### 수정
| 파일 | 변경 내용 |
|---|---|
| `AdminEventController.java` | POST/GET/PUT/DELETE + dashboard 엔드포인트 추가 |
| `GradeRepository.java` | `deleteByScheduleId()` 추가 |
| `ZoneRepository.java` | `deleteByScheduleId()` 추가 |
| `ScheduleRepository.java` | `deleteByConcertId()` + Mono import 추가 |
| `SeatRepository.java` | `findSoldSeatCountByScheduleIdGroupByGrade()`, `deleteByScheduleId()` 추가 |

## 엔드포인트
| Method | Path | 설명 |
|---|---|---|
| POST | `/api/v1/admin/events` | 이벤트 생성 (Concert+Schedule+Grade+Zone+Seat 일괄) |
| GET | `/api/v1/admin/events` | 이벤트 목록 |
| GET | `/api/v1/admin/events/{scheduleId}` | 이벤트 상세 (grades, zones 포함) |
| PUT | `/api/v1/admin/events/{scheduleId}` | 이벤트 수정 (기본 정보) |
| DELETE | `/api/v1/admin/events/{scheduleId}` | 이벤트 삭제 (seats→zones→grades→schedule→concert 순서) |
| GET | `/api/v1/admin/events/{scheduleId}/dashboard` | 등급별 판매/잔여석 현황 |

## 이벤트 생성 플로우
1. Concert 생성 (title, artist, venue, tenantId)
2. Schedule 생성 (dateTime, totalSeats, ticketOpenAt, ticketCloseAt, trackPolicy)
3. Grade 저장 (등급별 가격)
4. Zone 저장 (구역별 등급, 좌석 수)
5. Seat 일괄 생성 (zone별 1~seatCount 번호 부여, 등급 가격 매핑)

## 컴파일 검증
`./gradlew compileJava` ✅ BUILD SUCCESSFUL