### PR TITLE
feat: #15 admin 엔드포인트 X-User-Role 헤더 검증

### DIFF
--- a/src/main/java/com/opentraum/event/global/filter/AdminRoleFilter.java
+++ b/src/main/java/com/opentraum/event/global/filter/AdminRoleFilter.java
@@ -1,0 +1,31 @@
+package com.opentraum.event.global.filter;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Component
+public class AdminRoleFilter implements WebFilter {
+
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private static final String ADMIN_PATTERN = "/api/v1/admin/**";
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+        String path = exchange.getRequest().getURI().getPath();
+
+        if (pathMatcher.match(ADMIN_PATTERN, path)) {
+            String role = exchange.getRequest().getHeaders().getFirst("X-User-Role");
+            if (!"ORGANIZER".equals(role)) {
+                exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
+                return exchange.getResponse().setComplete();
+            }
+        }
+
+        return chain.filter(exchange);
+    }
+}


### PR DESCRIPTION
## 개요
event-service admin 엔드포인트에서 X-User-Role 헤더를 검증하여 ORGANIZER만 접근 가능하도록 한다 (Defense in Depth).

closes #15

## 변경 사항
| 파일 | 변경 |
|---|---|
| `AdminRoleFilter.java` (신규) | WebFilter — `/api/v1/admin/**` 경로에서 X-User-Role=ORGANIZER 검증, 아니면 403 |

## 컴파일 검증
- `./gradlew compileJava` ✅ BUILD SUCCESSFUL