### PR TITLE
feat: #17 테넌트 자동 필터링 (admin CRUD)

### DIFF
--- a/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
+++ b/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
@@ -31,46 +31,56 @@ public class AdminEventController {
 
     @Operation(summary = "이벤트 생성")
     @PostMapping
-    public Mono<ResponseEntity<AdminEventResponse>> createEvent(@Valid @RequestBody AdminEventCreateRequest request) {
-        return adminEventService.createEvent(request)
+    public Mono<ResponseEntity<AdminEventResponse>> createEvent(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @Valid @RequestBody AdminEventCreateRequest request) {
+        return adminEventService.createEvent(tenantId, request)
                 .map(ResponseEntity::ok);
     }
 
     @Operation(summary = "이벤트 목록 조회")
     @GetMapping
-    public Mono<ResponseEntity<List<AdminEventResponse>>> listEvents() {
-        return adminEventService.listEvents()
+    public Mono<ResponseEntity<List<AdminEventResponse>>> listEvents(
+            @RequestHeader("X-Tenant-Id") String tenantId) {
+        return adminEventService.listEvents(tenantId)
                 .collectList()
                 .map(ResponseEntity::ok);
     }
 
     @Operation(summary = "이벤트 상세 조회")
     @GetMapping("/{scheduleId}")
-    public Mono<ResponseEntity<AdminEventResponse>> getEvent(@PathVariable Long scheduleId) {
-        return adminEventService.getEvent(scheduleId)
+    public Mono<ResponseEntity<AdminEventResponse>> getEvent(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @PathVariable Long scheduleId) {
+        return adminEventService.getEvent(tenantId, scheduleId)
                 .map(ResponseEntity::ok);
     }
 
     @Operation(summary = "이벤트 수정")
     @PutMapping("/{scheduleId}")
     public Mono<ResponseEntity<AdminEventResponse>> updateEvent(
+            @RequestHeader("X-Tenant-Id") String tenantId,
             @PathVariable Long scheduleId,
             @Valid @RequestBody AdminEventCreateRequest request) {
-        return adminEventService.updateEvent(scheduleId, request)
+        return adminEventService.updateEvent(tenantId, scheduleId, request)
                 .map(ResponseEntity::ok);
     }
 
     @Operation(summary = "이벤트 삭제")
     @DeleteMapping("/{scheduleId}")
-    public Mono<ResponseEntity<Void>> deleteEvent(@PathVariable Long scheduleId) {
-        return adminEventService.deleteEvent(scheduleId)
+    public Mono<ResponseEntity<Void>> deleteEvent(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @PathVariable Long scheduleId) {
+        return adminEventService.deleteEvent(tenantId, scheduleId)
                 .then(Mono.just(ResponseEntity.noContent().<Void>build()));
     }
 
     @Operation(summary = "판매 현황 대시보드")
     @GetMapping("/{scheduleId}/dashboard")
-    public Mono<ResponseEntity<AdminDashboardResponse>> getDashboard(@PathVariable Long scheduleId) {
-        return adminEventService.getDashboard(scheduleId)
+    public Mono<ResponseEntity<AdminDashboardResponse>> getDashboard(
+            @RequestHeader("X-Tenant-Id") String tenantId,
+            @PathVariable Long scheduleId) {
+        return adminEventService.getDashboard(tenantId, scheduleId)
                 .map(ResponseEntity::ok);
     }
 }

--- a/src/main/java/com/opentraum/event/domain/admin/dto/AdminEventCreateRequest.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/AdminEventCreateRequest.java
@@ -30,8 +30,6 @@ public class AdminEventCreateRequest {
     private LocalDateTime ticketCloseAt;
     @NotBlank
     private String trackPolicy;
-    @NotBlank
-    private String tenantId;
 
     @NotEmpty
     private List<GradeInput> grades;

--- a/src/main/java/com/opentraum/event/domain/admin/service/AdminEventService.java
+++ b/src/main/java/com/opentraum/event/domain/admin/service/AdminEventService.java
@@ -31,12 +31,12 @@ public class AdminEventService {
     private final ZoneRepository zoneRepository;
     private final SeatRepository seatRepository;
 
-    public Mono<AdminEventResponse> createEvent(AdminEventCreateRequest request) {
+    public Mono<AdminEventResponse> createEvent(String tenantId, AdminEventCreateRequest request) {
         Concert concert = Concert.builder()
                 .title(request.getTitle())
                 .artist(request.getArtist())
                 .venue(request.getVenue())
-                .tenantId(request.getTenantId())
+                .tenantId(tenantId)
                 .createdAt(LocalDateTime.now())
                 .updatedAt(LocalDateTime.now())
                 .build();
@@ -110,20 +110,22 @@ public class AdminEventService {
                 .doOnSuccess(r -> log.info("이벤트 생성 완료: concertId={}, scheduleId={}", r.getConcertId(), r.getScheduleId()));
     }
 
-    public Mono<AdminEventResponse> getEvent(Long scheduleId) {
+    public Mono<AdminEventResponse> getEvent(String tenantId, Long scheduleId) {
         return scheduleRepository.findById(scheduleId)
                 .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
                 .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .filter(concert -> tenantId.equals(concert.getTenantId()))
+                        .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
                         .flatMap(concert -> Mono.zip(
                                 gradeRepository.findByScheduleId(scheduleId).collectList(),
                                 zoneRepository.findByScheduleId(scheduleId).collectList()
                         ).map(tuple -> buildResponse(concert, schedule, tuple.getT1(), tuple.getT2()))));
     }
 
-    public Flux<AdminEventResponse> listEvents() {
-        return scheduleRepository.findAll()
-                .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
-                        .map(concert -> AdminEventResponse.builder()
+    public Flux<AdminEventResponse> listEvents(String tenantId) {
+        return concertRepository.findByTenantId(tenantId)
+                .flatMap(concert -> scheduleRepository.findByConcertId(concert.getId())
+                        .map(schedule -> AdminEventResponse.builder()
                                 .concertId(concert.getId())
                                 .scheduleId(schedule.getId())
                                 .title(concert.getTitle())
@@ -139,10 +141,12 @@ public class AdminEventService {
                                 .build()));
     }
 
-    public Mono<AdminEventResponse> updateEvent(Long scheduleId, AdminEventCreateRequest request) {
+    public Mono<AdminEventResponse> updateEvent(String tenantId, Long scheduleId, AdminEventCreateRequest request) {
         return scheduleRepository.findById(scheduleId)
                 .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
                 .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .filter(concert -> tenantId.equals(concert.getTenantId()))
+                        .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
                         .flatMap(concert -> {
                             concert.setTitle(request.getTitle());
                             concert.setArtist(request.getArtist());
@@ -160,24 +164,29 @@ public class AdminEventService {
                                     scheduleRepository.save(schedule)
                             );
                         })
-                        .flatMap(tuple -> getEvent(scheduleId)));
+                        .flatMap(tuple -> getEvent(tenantId, scheduleId)));
     }
 
-    public Mono<Void> deleteEvent(Long scheduleId) {
-        return scheduleRepository.findById(scheduleId)
-                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
-                .flatMap(schedule -> seatRepository.deleteByScheduleId(scheduleId)
-                        .then(zoneRepository.deleteByScheduleId(scheduleId))
-                        .then(gradeRepository.deleteByScheduleId(scheduleId))
-                        .then(scheduleRepository.deleteById(scheduleId))
-                        .then(concertRepository.deleteById(schedule.getConcertId())))
-                .doOnSuccess(v -> log.info("이벤트 삭제 완료: scheduleId={}", scheduleId));
-    }
-
-    public Mono<AdminDashboardResponse> getDashboard(Long scheduleId) {
+    public Mono<Void> deleteEvent(String tenantId, Long scheduleId) {
         return scheduleRepository.findById(scheduleId)
                 .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
                 .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .filter(concert -> tenantId.equals(concert.getTenantId()))
+                        .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
+                        .then(seatRepository.deleteByScheduleId(scheduleId)
+                        .then(zoneRepository.deleteByScheduleId(scheduleId))
+                        .then(gradeRepository.deleteByScheduleId(scheduleId))
+                        .then(scheduleRepository.deleteById(scheduleId))
+                        .then(concertRepository.deleteById(schedule.getConcertId()))))
+                .doOnSuccess(v -> log.info("이벤트 삭제 완료: scheduleId={}", scheduleId));
+    }
+
+    public Mono<AdminDashboardResponse> getDashboard(String tenantId, Long scheduleId) {
+        return scheduleRepository.findById(scheduleId)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
+                .flatMap(schedule -> concertRepository.findById(schedule.getConcertId())
+                        .filter(concert -> tenantId.equals(concert.getTenantId()))
+                        .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.SCHEDULE_NOT_FOUND)))
                         .flatMap(concert -> Mono.zip(
                                 seatRepository.findSeatCountByScheduleIdGroupByGrade(scheduleId).collectList(),
                                 seatRepository.findSoldSeatCountByScheduleIdGroupByGrade(scheduleId).collectList()


### PR DESCRIPTION
## 개요
admin 이벤트 CRUD에서 X-Tenant-Id 헤더 기반으로 테넌트를 자동 설정/필터링한다.

closes #17

## 변경 사항
| 파일 | 변경 |
|---|---|
| `AdminEventController.java` | X-Tenant-Id 헤더 수신, 모든 메서드에 tenantId 전달 |
| `AdminEventService.java` | createEvent/listEvents/getEvent/updateEvent/deleteEvent/getDashboard 전부 tenantId 기반 필터링 |
| `AdminEventCreateRequest.java` | tenantId 필드 제거 (헤더 기반) |

## 컴파일 검증
- `./gradlew compileJava` ✅ BUILD SUCCESSFUL