### PR TITLE
fix: R2DBC URL 스킴 mariadb → mysql 수정

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     name: opentraum-event-service
 
   r2dbc:
-    url: r2dbc:mariadb://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/${DB_NAME:opentraum_event}
+    url: r2dbc:mysql://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/${DB_NAME:opentraum_event}
     username: ${DB_USERNAME:opentraum}
     password: ${DB_PASSWORD:opentraum123!}
     pool:
@@ -62,7 +62,7 @@ spring:
       on-profile: prod
 
   r2dbc:
-    url: r2dbc:mariadb://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/${DB_NAME:opentraum_event}
+    url: r2dbc:mysql://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/${DB_NAME:opentraum_event}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 


### PR DESCRIPTION
Closes #29

## Summary
- `io.asyncer:r2dbc-mysql` 드라이버가 `mysql` 스킴으로 등록되므로 URL을 `r2dbc:mysql://`로 변경

## Test plan
- [x] K8s에서 정상 동작 확인
- [x] `/actuator/health` → R2DBC: UP, database: MySQL