### PR TITLE
feat: k8s 매니페스트 운영 설정 반영

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -5,10 +5,12 @@ metadata:
   namespace: opentraum
   labels:
     app: event-service
+    app.kubernetes.io/name: event-service
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: event
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       app: event-service
@@ -16,10 +18,11 @@ spec:
     metadata:
       labels:
         app: event-service
+        app.kubernetes.io/name: event-service
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: event
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 30
       imagePullSecrets:
         - name: harbor-secret
       priorityClassName: opentraum-medium
@@ -43,11 +46,18 @@ spec:
               podAffinityTerm:
                 labelSelector:
                   matchExpressions:
-                    - key: app
+                    - key: app.kubernetes.io/name
                       operator: In
                       values:
                         - event-service
                 topologyKey: kubernetes.io/hostname
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/part-of: opentraum
       containers:
         - name: event-service
           image: amdp-registry.skala-ai.com/skala26a-cloud/opentraum-event-service:latest
@@ -59,58 +69,37 @@ spec:
             - configMapRef:
                 name: opentraum-config
           env:
-            - name: DB_HOST
-              value: "opentraum-mariadb.mariadb"
-            - name: DB_PORT
-              value: "3306"
-            - name: DB_NAME
-              value: "opentraum_event"
-            - name: DB_USERNAME
-              value: "opentraum"
-            - name: DB_PASSWORD
-              value: "opentraum123!"
             - name: SPRING_R2DBC_URL
-              value: "r2dbc:mysql://opentraum-mariadb.mariadb:3306/opentraum_event"
+              value: "r2dbc:mysql://event-db.kafka:3306/event"
             - name: SPRING_R2DBC_USERNAME
-              value: "opentraum"
+              valueFrom:
+                secretKeyRef:
+                  name: event-db-secret
+                  key: mariadb-user
             - name: SPRING_R2DBC_PASSWORD
-              value: "opentraum123!"
+              valueFrom:
+                secretKeyRef:
+                  name: event-db-secret
+                  key: mariadb-password
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: "my-kafka-cluster-kafka-bootstrap.kafka:9092"
+            - name: OTLP_TRACING_ENDPOINT
+              value: "http://alloy-otlp.monitoring:4318/v1/traces"
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: opentraum-secrets
                   key: OPENAI_API_KEY
+                  optional: true
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION
-              value: "true"
+              value: "false"
           resources:
             requests:
-              memory: "768Mi"
-              cpu: "500m"
+              memory: "512Mi"
+              cpu: "250m"
             limits:
               memory: "768Mi"
               cpu: "500m"
-          startupProbe:
-            httpGet:
-              path: /actuator/health
-              port: 8083
-            initialDelaySeconds: 5
-            periodSeconds: 3
-            timeoutSeconds: 3
-            failureThreshold: 20
-          livenessProbe:
-            httpGet:
-              path: /actuator/health
-              port: 8083
-            periodSeconds: 10
-            timeoutSeconds: 3
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /actuator/health
-              port: 8083
-            periodSeconds: 5
-            timeoutSeconds: 3
-            failureThreshold: 2
       restartPolicy: Always


### PR DESCRIPTION
## Summary
- DB 호스트 변경: `opentraum-mariadb.mariadb` → `event-db.kafka` (CDC per-service DB)
- DB credentials 평문 → `event-db-secret` Secret 참조
- KAFKA_BOOTSTRAP_SERVERS, OTLP_TRACING_ENDPOINT env 추가
- OPENAI_API_KEY Secret 참조 (optional)
- topologySpreadConstraints 추가
- terminationGracePeriodSeconds 10 → 30
- SPRING_MAIN_LAZY_INITIALIZATION true → false
- resources requests 512Mi/250m, limits 768Mi/500m
- 기존 평문 DB env / Probe 제거
- 라벨 `app.kubernetes.io/name`, `revisionHistoryLimit: 2` 추가

## Why
OpenTraum-Infra `k8s-manual/event-service/` 의 운영 설정을 본 레포 `k8s/` 로 이관해 ArgoCD GitOps 자동 배포 전환 준비를 완료합니다. CDC per-service DB 분리(event-db.kafka) 와 분산 추적(OTLP) 설정이 함께 반영됩니다.

## Test plan
- [ ] `event-db-secret` 클러스터 배포 + `event-db.kafka` 가용성 확인 후 ArgoCD sync
- [ ] 새 Pod env 에 Secret / OTLP / KAFKA_BOOTSTRAP_SERVERS 정상 주입 확인
- [ ] Probe 제거 후 SAGA 상태 전이 정상 확인

Closes #35