### PR TITLE
feat: schedule.tenant_id 컬럼 + SeatHeld payload에 tenant_id 자동 머지

### DIFF
--- a/src/main/java/com/opentraum/event/domain/admin/service/AdminEventService.java
+++ b/src/main/java/com/opentraum/event/domain/admin/service/AdminEventService.java
@@ -48,6 +48,7 @@ public class AdminEventService {
                 .flatMap(savedConcert -> {
                     Schedule schedule = Schedule.builder()
                             .concertId(savedConcert.getId())
+                            .tenantId(tenantId)
                             .dateTime(request.getDateTime())
                             .totalSeats(request.getTotalSeats())
                             .ticketOpenAt(request.getTicketOpenAt())

--- a/src/main/java/com/opentraum/event/domain/concert/entity/Schedule.java
+++ b/src/main/java/com/opentraum/event/domain/concert/entity/Schedule.java
@@ -19,6 +19,8 @@ public class Schedule {
 
     private Long concertId;
 
+    private String tenantId;
+
     private LocalDateTime dateTime;
 
     private Integer totalSeats;

--- a/src/main/java/com/opentraum/event/domain/internal/dto/ScheduleInfo.java
+++ b/src/main/java/com/opentraum/event/domain/internal/dto/ScheduleInfo.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 public class ScheduleInfo {
     private Long id;
     private Long concertId;
+    private String tenantId;
     private LocalDateTime ticketOpenAt;
     private String status;
     private String trackPolicy;
@@ -19,6 +20,7 @@ public class ScheduleInfo {
         return ScheduleInfo.builder()
                 .id(schedule.getId())
                 .concertId(schedule.getConcertId())
+                .tenantId(schedule.getTenantId())
                 .ticketOpenAt(schedule.getTicketOpenAt())
                 .status(schedule.getStatus())
                 .trackPolicy(schedule.getTrackPolicy())

--- a/src/main/java/com/opentraum/event/domain/seat/service/SeatSagaService.java
+++ b/src/main/java/com/opentraum/event/domain/seat/service/SeatSagaService.java
@@ -1,5 +1,6 @@
 package com.opentraum.event.domain.seat.service;
 
+import com.opentraum.event.domain.concert.repository.ScheduleRepository;
 import com.opentraum.event.domain.outbox.service.OutboxService;
 import com.opentraum.event.domain.seat.dto.SeatKey;
 import com.opentraum.event.domain.seat.entity.Seat;
@@ -43,6 +44,7 @@ public class SeatSagaService {
     private final SeatRepository seatRepository;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
     private final OutboxService outboxService;
+    private final ScheduleRepository scheduleRepository;
 
     /**
      * 배치 HOLD. Redis SETNX + DB status=HELD + Outbox SeatHeld.
@@ -286,7 +288,14 @@ public class SeatSagaService {
         payload.put("schedule_id", scheduleId);
         payload.put("seats", toSeatJson(acquired));
         payload.put("held_until", HELD_UNTIL_FORMAT.format(heldUntil));
-        return outboxService.publish(reservationId, AGGREGATE_TYPE, "SeatHeld", sagaId, payload).then();
+        // 멀티테넌시 전파: schedule.tenant_id를 SeatHeld payload에 자동 머지
+        return scheduleRepository.findById(scheduleId)
+                .flatMap(schedule -> {
+                    payload.put("tenant_id", schedule.getTenantId());
+                    return outboxService.publish(reservationId, AGGREGATE_TYPE, "SeatHeld", sagaId, payload);
+                })
+                .switchIfEmpty(outboxService.publish(reservationId, AGGREGATE_TYPE, "SeatHeld", sagaId, payload).then(Mono.empty()))
+                .then();
     }
 
     private Mono<Void> compensateHold(Long scheduleId, Long reservationId, String sagaId,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS concerts (
 CREATE TABLE IF NOT EXISTS schedules (
     id              BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
     concert_id      BIGINT          NOT NULL,
+    tenant_id       VARCHAR(64)     NOT NULL DEFAULT 'default',
     date_time       TIMESTAMP       NOT NULL,
     total_seats     INT             NOT NULL,
     ticket_open_at  TIMESTAMP       NOT NULL,
@@ -30,6 +31,7 @@ CREATE TABLE IF NOT EXISTS schedules (
     track_policy    VARCHAR(20)     NOT NULL DEFAULT 'DUAL_TRACK',
     created_at      TIMESTAMP       DEFAULT CURRENT_TIMESTAMP,
     INDEX idx_schedules_concert (concert_id),
+    INDEX idx_schedules_tenant (tenant_id),
     FOREIGN KEY (concert_id) REFERENCES concerts(id)
 );
 


### PR DESCRIPTION
## 배경

멀티테넌시 모델 데이터 전파를 위해 schedule이 tenant_id를 갖고 SeatHeld outbox로 payment-service에 전파.

## 변경 내용

- schedules 테이블에 tenant_id VARCHAR(64) 컬럼 + 인덱스
- Schedule 엔티티 tenantId 필드
- ScheduleInfo dto(internal API)에 tenantId 포함
- AdminEventService.createEvent: schedule.tenantId에 ORGANIZER tenant 자동 채움
- SeatSagaService.publishSeatHeld: schedule 조회 후 tenant_id를 SeatHeld outbox payload에 flatMap으로 명시적 머지
- SeatSagaService에 ScheduleRepository 주입

## 검증

- 새 콘서트 생성 → schedules.tenant_id="org-553275" ✅
- outbox SeatHeld payload에 \`"tenant_id":"org-553275"\` 포함 ✅

## 의존성

- payment-service의 PR (Payment.tenantId String 통일 + 매출 조회)과 atomic 머지 필요
- event-db migration: \`ALTER TABLE schedules ADD COLUMN tenant_id VARCHAR(64) NOT NULL DEFAULT 'default' AFTER concert_id;\`