### PR TITLE
chore: 분산 트레이싱(OpenTelemetry/Tempo) 제거 (#41)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
-    // OpenTelemetry Tracing (W3C propagation -> Grafana Alloy)
-    implementation 'io.micrometer:micrometer-tracing-bridge-otel'
-    implementation 'io.opentelemetry:opentelemetry-exporter-otlp'
-
     // Validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -85,8 +85,6 @@ spec:
               value: "my-kafka-cluster-kafka-bootstrap.kafka:9092"
             - name: TZ
               value: "Asia/Seoul"
-            - name: OTLP_TRACING_ENDPOINT
-              value: "http://alloy-otlp.monitoring:4318/v1/traces"
             - name: OPENAI_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/src/main/java/com/opentraum/event/EventServiceApplication.java
+++ b/src/main/java/com/opentraum/event/EventServiceApplication.java
@@ -7,8 +7,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class EventServiceApplication {
 
     public static void main(String[] args) {
-        // Micrometer Tracing + Reactor: traceId/spanId 전파를 위해 자동 컨텍스트 전파 활성화.
-        reactor.core.publisher.Hooks.enableAutomaticContextPropagation();
         SpringApplication.run(EventServiceApplication.class, args);
     }
 }

--- a/src/main/java/com/opentraum/event/config/KafkaConfig.java
+++ b/src/main/java/com/opentraum/event/config/KafkaConfig.java
@@ -33,10 +33,7 @@ public class KafkaConfig {
 
     @Bean
     public KafkaTemplate<String, String> kafkaTemplate() {
-        KafkaTemplate<String, String> template = new KafkaTemplate<>(producerFactory());
-        // Producer 측 OTel span 생성 + W3C traceparent 헤더 주입.
-        template.setObservationEnabled(true);
-        return template;
+        return new KafkaTemplate<>(producerFactory());
     }
 
     @Bean
@@ -61,8 +58,6 @@ public class KafkaConfig {
         factory.getContainerProperties().setShutdownTimeout(10_000L);
         factory.getContainerProperties().setAckMode(
                 org.springframework.kafka.listener.ContainerProperties.AckMode.RECORD);
-        // Consumer 측 OTel span 생성 + traceparent 헤더 복원.
-        factory.getContainerProperties().setObservationEnabled(true);
         return factory;
     }
 }

--- a/src/main/java/com/opentraum/event/domain/outbox/entity/OutboxEvent.java
+++ b/src/main/java/com/opentraum/event/domain/outbox/entity/OutboxEvent.java
@@ -46,9 +46,6 @@ public class OutboxEvent {
 
     private String payload;
 
-    @Column("trace_id")
-    private String traceId;
-
     @Column("occurred_at")
     private LocalDateTime occurredAt;
 }

--- a/src/main/java/com/opentraum/event/domain/outbox/service/OutboxService.java
+++ b/src/main/java/com/opentraum/event/domain/outbox/service/OutboxService.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opentraum.event.domain.outbox.entity.OutboxEvent;
 import com.opentraum.event.domain.outbox.repository.OutboxRepository;
-import io.micrometer.tracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -34,14 +32,11 @@ public class OutboxService {
 
     private final OutboxRepository outboxRepository;
     private final ObjectMapper objectMapper;
-    private final Tracer tracer;
 
     public OutboxService(OutboxRepository outboxRepository,
-                         ObjectMapper objectMapper,
-                         @Autowired(required = false) Tracer tracer) {
+                         ObjectMapper objectMapper) {
         this.outboxRepository = outboxRepository;
         this.objectMapper = objectMapper;
-        this.tracer = tracer;
     }
 
     /**
@@ -78,8 +73,6 @@ public class OutboxService {
                     "Failed to serialize outbox payload for eventType=" + eventType, e));
         }
 
-        String traceId = currentTraceId();
-
         OutboxEvent event = OutboxEvent.builder()
                 .eventId(UUID.randomUUID().toString())
                 .aggregateId(aggregateId)
@@ -87,20 +80,13 @@ public class OutboxService {
                 .eventType(eventType)
                 .sagaId(sagaId)
                 .payload(payloadJson)
-                .traceId(traceId)
                 .occurredAt(now)
                 .build();
 
         return outboxRepository.save(event)
                 .doOnSuccess(saved -> log.debug(
-                        "outbox published: eventType={}, eventId={}, sagaId={}, aggregateId={}, traceId={}",
+                        "outbox published: eventType={}, eventId={}, sagaId={}, aggregateId={}",
                         saved.getEventType(), saved.getEventId(), saved.getSagaId(),
-                        saved.getAggregateId(), saved.getTraceId()));
-    }
-
-    private String currentTraceId() {
-        if (tracer == null) return null;
-        var span = tracer.currentSpan();
-        return span != null ? span.context().traceId() : null;
+                        saved.getAggregateId()));
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,14 +47,6 @@ openai:
   model: ${OPENAI_MODEL:gpt-4o-mini}
 
 management:
-  tracing:
-    sampling:
-      probability: 1.0
-    propagation:
-      type: w3c
-  otlp:
-    tracing:
-      endpoint: ${OTLP_TRACING_ENDPOINT:http://alloy.monitoring:4318/v1/traces}
   endpoints:
     web:
       exposure:
@@ -67,8 +59,6 @@ management:
       application: ${spring.application.name}
 
 logging:
-  pattern:
-    level: "%5p [${spring.application.name:event-service},%X{traceId:-},%X{spanId:-}]"
   level:
     root: INFO
     com.opentraum.event: DEBUG

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -102,12 +102,10 @@ CREATE TABLE IF NOT EXISTS outbox_events (
     event_type VARCHAR(64) NOT NULL,
     saga_id CHAR(36) NOT NULL,
     payload JSON NOT NULL,
-    trace_id CHAR(32) NULL,
     occurred_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
     INDEX idx_outbox_aggregate (aggregate_type, aggregate_id),
     INDEX idx_outbox_saga (saga_id),
-    INDEX idx_outbox_occurred (occurred_at),
-    INDEX idx_outbox_trace (trace_id)
+    INDEX idx_outbox_occurred (occurred_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- processed_events: Consumer 멱등성


### PR DESCRIPTION
## 개요

이슈 #41 - event-service에 남아 있던 OpenTelemetry / Tempo 분산 트레이싱 흔적을 의존성, 설정, 코드, DB 스키마에서 모두 제거합니다.

## 변경 파일

- `build.gradle`
  - `io.micrometer:micrometer-tracing-bridge-otel` 의존성 제거
  - `io.opentelemetry:opentelemetry-exporter-otlp` 의존성 제거
- `EventServiceApplication.java`
  - `Hooks.enableAutomaticContextPropagation()` 호출 및 관련 주석 제거
- `application.yml`
  - `management.tracing` 블록 제거
  - `management.otlp.tracing` 블록 제거
  - `logging.pattern.level`에서 `%X{traceId:-},%X{spanId:-}` 제거
- `OutboxEvent.java`
  - `traceId` 필드와 `@Column("trace_id")` 제거
- `OutboxService.java`
  - `Tracer` 의존성 제거
  - `currentTraceId()` 메서드 제거
  - 빌더의 `.traceId(traceId)` 호출 제거
  - 로그 포맷의 `traceId={}` placeholder와 인자 제거
- `schema.sql`
  - `outbox_events.trace_id` 컬럼 제거
  - `idx_outbox_trace` 인덱스 제거

## 영향

- 트레이싱 정보가 더 이상 수집되거나 저장되지 않습니다.
- `outbox_events` 테이블 스키마가 변경되므로 기존 DB는 폐기 후 재생성합니다 (운영 데이터 아님).
- 관측성은 Prometheus(metrics)와 Loki(logs) 조합으로 단순화됩니다.

## 검증

- [ ] `./gradlew compileJava` 통과
- [ ] mariadb event DB 재생성 (PVC 삭제 + StatefulSet 재기동)
- [ ] 파드 정상 기동 및 outbox 발행 정상 확인

Closes #41