### PR TITLE
fix: 내부 좌석 상태 API를 HOLD 해제로 제한

### DIFF
--- a/src/main/java/com/opentraum/event/domain/internal/controller/InternalSeatController.java
+++ b/src/main/java/com/opentraum/event/domain/internal/controller/InternalSeatController.java
@@ -4,6 +4,7 @@ import com.opentraum.event.domain.internal.dto.GradeSeatCountResponse;
 import com.opentraum.event.domain.internal.dto.SeatHoldRequest;
 import com.opentraum.event.domain.internal.dto.SeatHoldResponse;
 import com.opentraum.event.domain.internal.dto.SeatInfo;
+import com.opentraum.event.domain.seat.entity.SeatStatus;
 import com.opentraum.event.domain.seat.repository.SeatRepository;
 import com.opentraum.event.domain.seat.service.SeatSagaService;
 import com.opentraum.event.global.exception.BusinessException;
@@ -21,6 +22,7 @@ import reactor.core.publisher.Mono;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -50,24 +52,51 @@ public class InternalSeatController {
     }
 
     /**
-     * @deprecated SAGA 전환 이후 좌석 상태는 Kafka 이벤트(ReservationCreated / PaymentCompleted /
-     * PaymentFailed 등)로만 변경한다. 이 REST 엔드포인트는 호환성 유지용으로만 남아있으며 Wave 3에서
-     * 제거 예정.
+     * 호환용 좌석 HOLD 해제 API.
+     *
+     * <p>신규 HOLD/SOLD 상태 전이는 SAGA 경로에서 처리한다. 이 엔드포인트는 기존 내부 호출자의
+     * HELD 좌석 해제 요청만 제한적으로 허용한다.
      */
-    @Deprecated
-    @Operation(summary = "[Deprecated] 좌석 상태 변경 — SAGA 이벤트 기반으로 전환됨",
-            description = "SAGA 전환 이후 직접 호출 금지. Kafka 이벤트로만 상태 전이.")
+    @Operation(summary = "좌석 HOLD 해제",
+            description = "기존 내부 호출자 호환용 API. status=AVAILABLE 요청만 허용하며 HELD 좌석만 해제한다.")
     @PutMapping("/status")
     public Mono<ResponseEntity<Void>> updateStatus(
             @RequestParam Long scheduleId,
             @RequestParam String zone,
             @RequestParam String seatNumber,
             @RequestParam String status) {
-        log.warn("[DEPRECATED] /api/v1/internal/seats/status direct call: scheduleId={}, zone={}, seat={}, status={}. "
-                        + "SAGA 전환 이후 이 경로는 제거 대상이다.",
+        log.info("Internal seat release request: scheduleId={}, zone={}, seat={}, status={}",
                 scheduleId, zone, seatNumber, status);
-        return seatRepository.updateStatusByScheduleIdAndZoneAndSeatNumber(status, scheduleId, zone, seatNumber)
-                .then(Mono.just(ResponseEntity.ok().<Void>build()));
+        String targetStatus = status == null ? "" : status.trim().toUpperCase(Locale.ROOT);
+        if (!SeatStatus.AVAILABLE.name().equals(targetStatus)) {
+            log.warn("Internal seat transition rejected: targetStatus={}, scheduleId={}, zone={}, seat={}",
+                    status, scheduleId, zone, seatNumber);
+            return Mono.error(new BusinessException(ErrorCode.INVALID_INPUT));
+        }
+
+        return seatRepository.findByScheduleIdAndZoneAndSeatNumber(scheduleId, zone, seatNumber)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.NO_AVAILABLE_SEATS)))
+                .flatMap(seatSagaService::reconcileExpiredHold)
+                .flatMap(seat -> {
+                    if (SeatStatus.AVAILABLE.name().equals(seat.getStatus())) {
+                        return Mono.just(ResponseEntity.ok().<Void>build());
+                    }
+                    if (!SeatStatus.HELD.name().equals(seat.getStatus())) {
+                        log.warn("Internal seat release rejected from status={}: scheduleId={}, zone={}, seat={}",
+                                seat.getStatus(), scheduleId, zone, seatNumber);
+                        return Mono.error(new BusinessException(ErrorCode.INVALID_INPUT));
+                    }
+                    return seatRepository.releaseHeldByCoordinate(scheduleId, zone, seatNumber)
+                            .flatMap(rows -> {
+                                if (rows > 0) {
+                                    return Mono.just(ResponseEntity.ok().<Void>build());
+                                }
+                                return seatRepository.findByScheduleIdAndZoneAndSeatNumber(scheduleId, zone, seatNumber)
+                                        .flatMap(latest -> SeatStatus.AVAILABLE.name().equals(latest.getStatus())
+                                                ? Mono.just(ResponseEntity.ok().<Void>build())
+                                                : Mono.error(new BusinessException(ErrorCode.INVALID_INPUT)));
+                            });
+                });
     }
 
     @Operation(summary = "등급별 좌석 수")

--- a/src/main/java/com/opentraum/event/domain/seat/repository/SeatRepository.java
+++ b/src/main/java/com/opentraum/event/domain/seat/repository/SeatRepository.java
@@ -114,6 +114,28 @@ public interface SeatRepository extends ReactiveCrudRepository<Seat, Long> {
             @Param("reservationId") Long reservationId);
 
     /**
+     * Legacy 내부 API용 HELD -> AVAILABLE 전이.
+     *
+     * <p>reservation_id 를 모르는 구형 호출자는 SOLD 전이나 HELD 생성에 사용할 수 없고,
+     * HELD 해제만 멱등적으로 허용한다.
+     */
+    @Modifying
+    @Query("""
+            UPDATE seats
+               SET status = 'AVAILABLE',
+                   held_until = NULL,
+                   reservation_id = NULL
+             WHERE schedule_id = :scheduleId
+               AND zone = :zone
+               AND seat_number = :seatNumber
+               AND status = 'HELD'
+            """)
+    Mono<Integer> releaseHeldByCoordinate(
+            @Param("scheduleId") Long scheduleId,
+            @Param("zone") String zone,
+            @Param("seatNumber") String seatNumber);
+
+    /**
      * reservation_id 로 점유된 전체 좌석 조회 (release 보상 시 좌석 좌표를 모를 때).
      */
     Flux<Seat> findByReservationId(Long reservationId);


### PR DESCRIPTION
## 작업 내용

- 내부 좌석 상태 변경 API를 기존 호환용 HOLD 해제 경로로 제한했습니다.
- `status=AVAILABLE` 요청만 허용하고, `HELD -> AVAILABLE` 전이만 수행합니다.
- 이미 AVAILABLE인 좌석은 idempotent하게 성공 처리합니다.
- SOLD 등 직접 전이하면 안 되는 상태 변경은 거부합니다.
- reservation id를 모르는 legacy caller를 위해 좌표 기반 HELD 해제 repository method를 추가했습니다.

## 배경 / 원인

SAGA 전환 이후 HOLD/SOLD 등 핵심 좌석 상태 전이는 이벤트 기반 경로에서 처리해야 합니다. 기존 내부 API가 임의 status를 직접 반영할 수 있으면 SAGA 상태와 좌석 상태가 어긋날 수 있어, 남겨야 하는 호환 범위를 HELD 해제로 제한했습니다.

## 팀 공유사항

- `/api/v1/internal/seats/status`는 제거 대상 API가 아니라 현재는 호환용 HOLD 해제 API로 유지됩니다.
- 이 API로 SOLD 전이나 HELD 생성은 불가능합니다.
- 기존 호출자는 `status=AVAILABLE` 해제 요청만 계속 사용할 수 있습니다.
- Gateway 경유 `/api/v1/internal/**`는 외부 라우트 미노출 기준으로 차단됩니다.
- 수동 K8s 배포 이미지 기준 E2E/API는 `74/74` 통과했지만, 이후 ArgoCD selfHeal 복구로 현재 클러스터 이미지는 GitOps 기준 이미지로 되돌아간 상태입니다. 이 PR이 merge되어야 같은 변경이 GitOps 배포에 반영됩니다.

## 검증

- `./gradlew test` 통과 또는 테스트 없음 확인
- `./gradlew bootJar` 통과
- 수동 배포 이미지 기준 K8s E2E/API `74/74` 통과

## 영향 범위

- event-service 내부 좌석 해제 API
- legacy 내부 호출자 호환 동작
- SAGA 좌석 상태 일관성

## 관련 이슈

- Related: #40
