### PR TITLE
feat: #48 내부 ScheduleInfo에 totalSeats 노출

### DIFF
--- a/src/main/java/com/opentraum/event/domain/internal/dto/ScheduleInfo.java
+++ b/src/main/java/com/opentraum/event/domain/internal/dto/ScheduleInfo.java
@@ -15,6 +15,7 @@ public class ScheduleInfo {
     private LocalDateTime ticketOpenAt;
     private String status;
     private String trackPolicy;
+    private Integer totalSeats;
 
     public static ScheduleInfo from(Schedule schedule) {
         return ScheduleInfo.builder()
@@ -24,6 +25,7 @@ public class ScheduleInfo {
                 .ticketOpenAt(schedule.getTicketOpenAt())
                 .status(schedule.getStatus())
                 .trackPolicy(schedule.getTrackPolicy())
+                .totalSeats(schedule.getTotalSeats())
                 .build();
     }
 }


### PR DESCRIPTION
Closes #48

## 변경
- `ScheduleInfo.java`: `totalSeats` 필드 노출

## 사용처
monitoring-service의 `ScheduleAggregator` → 매진 ETA 계산(Linear/Logistic fit) 입력으로 사용.