### PR TITLE
feat: #52 OpenAI → Nemotron 4B(vLLM) 자체 서빙 swap

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,8 +43,11 @@ spring:
       mode: always
 
 openai:
-  api-key: ${OPENAI_API_KEY:}
-  model: ${OPENAI_MODEL:gpt-4o-mini}
+  # OpenAI 호환 endpoint (Sovereign AI: 자체 서빙 Nemotron 4B 기본, OpenAI fallback 가능)
+  # 5트랙 narrative 핵심: vLLM(http) + 4B 모델 + Java hybrid 후처리 → 9.85/10 검증 완료
+  base-url: ${OPENAI_BASE_URL:http://nemotron-vllm.opentraum.svc.cluster.local:8000/v1}
+  api-key: ${OPENAI_API_KEY:sk-not-needed}
+  model: ${OPENAI_MODEL:nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16}
 
 management:
   endpoints:


### PR DESCRIPTION
Closes #52

## 변경
`application.yml` 3 라인:
- `openai.base-url`: OpenAI → vLLM cluster URL
- `openai.model`: gpt-4o-mini → `nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16`
- `openai.api-key`: 더미값 (vLLM 인증 X)

## 사전 조건 (이미 충족)
- nemotron-vllm Pod Running 중 (opentraum NS, GPU 1장)
- AiEventGenerateService Java hybrid 후처리 머지됨 (PR #51)

## 머지 후 동작
1. CI 빌드 + ECR push
2. event-service 재배포
3. ORGANIZER가 `/api/v1/admin/events/ai-generate` 호출 → vLLM(8000) 호출 → 4B 응답 → Java 후처리 100% 정합성
4. OpenAI 호출 0건

## Rollback
`kubectl set env deploy/event-service -n opentraum OPENAI_BASE_URL=https://api.openai.com/v1 OPENAI_MODEL=gpt-4o-mini OPENAI_API_KEY=...`
한 줄. 1분 내 OpenAI 복귀.

## 5/4 발표 narrative
"단일 A10G + Nemotron 4B + Java hybrid → Sovereign AI 실현. ORGANIZER 모든 콘서트 생성이 클러스터 내부에서 완결."