### PR TITLE
feat: #54 Track 4 4.2 event-service flux-image 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // AWS SDK v2 — S3 (event cover image upload + presigned URL)
+    implementation platform('software.amazon.awssdk:bom:2.29.34')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:auth'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -89,6 +89,22 @@ spec:
                   name: opentraum-secrets
                   key: OPENAI_API_KEY
                   optional: true
+            - name: FLUX_BASE_URL
+              value: "http://flux-image.opentraum.svc.cluster.local:8000"
+            - name: S3_BUCKET
+              value: "opentraum-assets"
+            - name: AWS_REGION
+              value: "ap-northeast-2"
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: event-aws-credentials
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: event-aws-credentials
+                  key: AWS_SECRET_ACCESS_KEY
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION

--- a/src/main/java/com/opentraum/event/config/FluxProperties.java
+++ b/src/main/java/com/opentraum/event/config/FluxProperties.java
@@ -1,0 +1,20 @@
+package com.opentraum.event.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "flux")
+public class FluxProperties {
+    private String baseUrl;
+    private int width = 1024;
+    private int height = 576;
+    private int steps = 4;
+    private double guidance = 0.0;
+    private int candidates = 3;
+    private int requestTimeoutSeconds = 60;
+}

--- a/src/main/java/com/opentraum/event/config/S3ClientConfig.java
+++ b/src/main/java/com/opentraum/event/config/S3ClientConfig.java
@@ -1,0 +1,32 @@
+package com.opentraum.event.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+@RequiredArgsConstructor
+public class S3ClientConfig {
+
+    private final S3Properties s3Properties;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(s3Properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(s3Properties.getRegion()))
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/opentraum/event/config/S3Properties.java
+++ b/src/main/java/com/opentraum/event/config/S3Properties.java
@@ -1,0 +1,16 @@
+package com.opentraum.event.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "s3")
+public class S3Properties {
+    private String region = "ap-northeast-2";
+    private String bucket;
+    private int presignHours = 24;
+}

--- a/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
+++ b/src/main/java/com/opentraum/event/domain/admin/controller/AdminEventController.java
@@ -4,6 +4,7 @@ import com.opentraum.event.domain.admin.dto.*;
 import com.opentraum.event.domain.admin.service.AdminEventService;
 import com.opentraum.event.domain.admin.service.AdminInsightService;
 import com.opentraum.event.domain.admin.service.AiEventGenerateService;
+import com.opentraum.event.domain.admin.service.EventCoverGenerateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -23,11 +24,21 @@ public class AdminEventController {
     private final AiEventGenerateService aiEventGenerateService;
     private final AdminEventService adminEventService;
     private final AdminInsightService adminInsightService;
+    private final EventCoverGenerateService eventCoverGenerateService;
 
     @Operation(summary = "AI 이벤트 구성 자동 생성")
     @PostMapping("/ai-generate")
     public Mono<ResponseEntity<AiGenerateResponse>> aiGenerate(@Valid @RequestBody AiGenerateRequest request) {
         return aiEventGenerateService.generate(request.getPrompt())
+                .map(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "이벤트 커버 이미지 자동 생성",
+            description = "이벤트 메타로 Nemotron tool call → flux-image 추론 → S3 업로드. 실패 시 카테고리별 default banner 폴백")
+    @PostMapping("/cover/generate")
+    public Mono<ResponseEntity<CoverGenerateResponse>> generateCover(
+            @Valid @RequestBody CoverGenerateRequest request) {
+        return eventCoverGenerateService.generate(request)
                 .map(ResponseEntity::ok);
     }
 

--- a/src/main/java/com/opentraum/event/domain/admin/dto/CoverGenerateRequest.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/CoverGenerateRequest.java
@@ -1,0 +1,24 @@
+package com.opentraum.event.domain.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CoverGenerateRequest {
+    @NotBlank
+    private String category;
+
+    @NotBlank
+    private String title;
+
+    @NotBlank
+    private String venue;
+
+    private String artist;
+
+    private String dateTime;
+}

--- a/src/main/java/com/opentraum/event/domain/admin/dto/CoverGenerateResponse.java
+++ b/src/main/java/com/opentraum/event/domain/admin/dto/CoverGenerateResponse.java
@@ -1,0 +1,15 @@
+package com.opentraum.event.domain.admin.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoverGenerateResponse {
+    private List<String> urls;
+    private boolean fallback;
+    private String model;
+    private double seconds;
+}

--- a/src/main/java/com/opentraum/event/domain/admin/service/EventCoverGenerateService.java
+++ b/src/main/java/com/opentraum/event/domain/admin/service/EventCoverGenerateService.java
@@ -1,0 +1,290 @@
+package com.opentraum.event.domain.admin.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opentraum.event.config.FluxProperties;
+import com.opentraum.event.config.OpenAiProperties;
+import com.opentraum.event.config.S3Properties;
+import com.opentraum.event.domain.admin.dto.CoverGenerateRequest;
+import com.opentraum.event.domain.admin.dto.CoverGenerateResponse;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.time.Duration;
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EventCoverGenerateService {
+
+    private final OpenAiProperties openAiProperties;
+    private final FluxProperties fluxProperties;
+    private final S3Properties s3Properties;
+    private final ObjectMapper objectMapper;
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    private WebClient nemotronClient;
+    private WebClient fluxClient;
+
+    @PostConstruct
+    void init() {
+        nemotronClient = WebClient.builder()
+                .baseUrl(openAiProperties.getBaseUrl())
+                .defaultHeader("Content-Type", "application/json")
+                .codecs(c -> c.defaultCodecs().maxInMemorySize(2 * 1024 * 1024))
+                .build();
+        fluxClient = WebClient.builder()
+                .baseUrl(fluxProperties.getBaseUrl())
+                .defaultHeader("Content-Type", "application/json")
+                .codecs(c -> c.defaultCodecs().maxInMemorySize(64 * 1024 * 1024))
+                .build();
+    }
+
+    public Mono<CoverGenerateResponse> generate(CoverGenerateRequest req) {
+        long t0 = System.currentTimeMillis();
+        return buildPromptDetails(req)
+                .flatMap(details -> callFluxAndUpload(req, details, t0))
+                .onErrorResume(e -> {
+                    log.error("cover generate failed for category={}: {}", req.getCategory(), e.toString());
+                    return Mono.just(fallbackResponse(req.getCategory(), t0));
+                });
+    }
+
+    /** Nemotron build_image_prompt function call → mood/season/palette/accent_objects JSON. */
+    @SuppressWarnings("unchecked")
+    private Mono<Map<String, Object>> buildPromptDetails(CoverGenerateRequest req) {
+        Map<String, Object> body = Map.of(
+                "model", openAiProperties.getModel(),
+                "messages", List.of(
+                        Map.of("role", "system", "content", IMAGE_PROMPT_SYSTEM),
+                        Map.of("role", "user", "content", composeUserMeta(req))
+                ),
+                "tools", List.of(Map.of("type", "function", "function", BUILD_IMAGE_PROMPT_SCHEMA)),
+                "tool_choice", Map.of("type", "function",
+                        "function", Map.of("name", "build_image_prompt"))
+        );
+        return nemotronClient.post()
+                .uri("/chat/completions")
+                .header("Authorization", "Bearer " + openAiProperties.getApiKey())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .map(resp -> {
+                    try {
+                        List<Map<String, Object>> choices = (List<Map<String, Object>>) resp.get("choices");
+                        Map<String, Object> message = (Map<String, Object>) choices.get(0).get("message");
+                        List<Map<String, Object>> tools = (List<Map<String, Object>>) message.get("tool_calls");
+                        Map<String, Object> fn = (Map<String, Object>) tools.get(0).get("function");
+                        String args = (String) fn.get("arguments");
+                        return objectMapper.readValue(args, new TypeReference<Map<String, Object>>() {});
+                    } catch (Exception e) {
+                        log.warn("parse build_image_prompt failed, using defaults: {}", e.toString());
+                        return defaultDetails();
+                    }
+                })
+                .onErrorReturn(defaultDetails());
+    }
+
+    private Map<String, Object> defaultDetails() {
+        return Map.of(
+                "mood", "cinematic",
+                "season", "any",
+                "time_of_day", "golden_hour",
+                "palette", List.of("deep blue", "violet"),
+                "accent_objects", List.of()
+        );
+    }
+
+    private String composeUserMeta(CoverGenerateRequest r) {
+        return "category=" + r.getCategory()
+                + ", title=" + r.getTitle()
+                + ", venue=" + r.getVenue()
+                + (r.getArtist() != null ? ", artist=" + r.getArtist() : "")
+                + (r.getDateTime() != null ? ", dateTime=" + r.getDateTime() : "");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Mono<CoverGenerateResponse> callFluxAndUpload(
+            CoverGenerateRequest req, Map<String, Object> details, long t0) {
+        String prompt = composePositive(req.getCategory(), details);
+        String negative = composeNegative(req.getCategory());
+        String correlationId = UUID.randomUUID().toString();
+        int candidates = fluxProperties.getCandidates();
+
+        Map<String, Object> fluxBody = new LinkedHashMap<>();
+        fluxBody.put("prompt", prompt);
+        fluxBody.put("negative_prompt", negative);
+        fluxBody.put("num_images", candidates);
+        fluxBody.put("width", fluxProperties.getWidth());
+        fluxBody.put("height", fluxProperties.getHeight());
+        fluxBody.put("num_inference_steps", fluxProperties.getSteps());
+        fluxBody.put("guidance_scale", fluxProperties.getGuidance());
+        fluxBody.put("seed", Math.abs(req.getCategory().hashCode()));
+
+        return fluxClient.post()
+                .uri("/generate")
+                .bodyValue(fluxBody)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .timeout(Duration.ofSeconds(fluxProperties.getRequestTimeoutSeconds()))
+                .flatMap(resp -> Mono.fromCallable(() -> {
+                    List<String> imagesB64 = (List<String>) resp.get("images");
+                    String model = (String) resp.getOrDefault("model", "unknown");
+                    List<String> urls = new ArrayList<>();
+                    for (int i = 0; i < imagesB64.size(); i++) {
+                        byte[] png = Base64.getDecoder().decode(imagesB64.get(i));
+                        String key = "events/" + correlationId + "/cover/" + i + ".png";
+                        s3Client.putObject(
+                                PutObjectRequest.builder()
+                                        .bucket(s3Properties.getBucket())
+                                        .key(key)
+                                        .contentType("image/png")
+                                        .build(),
+                                RequestBody.fromBytes(png));
+                        urls.add(presign(key));
+                    }
+                    double seconds = (System.currentTimeMillis() - t0) / 1000.0;
+                    log.info("cover generate ok category={} candidates={} elapsed={}s",
+                            req.getCategory(), urls.size(), seconds);
+                    return CoverGenerateResponse.builder()
+                            .urls(urls)
+                            .fallback(false)
+                            .model(model)
+                            .seconds(seconds)
+                            .build();
+                }).subscribeOn(Schedulers.boundedElastic()));
+    }
+
+    private String presign(String key) {
+        GetObjectRequest get = GetObjectRequest.builder()
+                .bucket(s3Properties.getBucket()).key(key).build();
+        GetObjectPresignRequest req = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofHours(s3Properties.getPresignHours()))
+                .getObjectRequest(get).build();
+        return s3Presigner.presignGetObject(req).url().toString();
+    }
+
+    private CoverGenerateResponse fallbackResponse(String category, long t0) {
+        String cat = SUPPORTED.contains(category) ? category : "OTHER";
+        String url = presign("defaults/" + cat + ".webp");
+        double seconds = (System.currentTimeMillis() - t0) / 1000.0;
+        return CoverGenerateResponse.builder()
+                .urls(List.of(url))
+                .fallback(true)
+                .model("default-banner")
+                .seconds(seconds)
+                .build();
+    }
+
+    private static final Set<String> SUPPORTED = Set.of(
+            "CONCERT", "SPORTS", "MUSICAL", "FANMEETING", "FESTIVAL", "EXHIBITION", "OTHER");
+
+    @SuppressWarnings("unchecked")
+    private String composePositive(String category, Map<String, Object> d) {
+        String mood = (String) d.getOrDefault("mood", "cinematic");
+        String tod = (String) d.getOrDefault("time_of_day", "golden_hour");
+        List<String> palette = (List<String>) d.getOrDefault("palette", List.of("deep blue", "violet"));
+        List<String> accents = (List<String>) d.getOrDefault("accent_objects", List.of());
+        String pal = String.join(" and ", palette);
+        String acc = accents.isEmpty() ? "" : ", " + String.join(", ", accents);
+
+        String prefix = "professional event poster background, photorealistic, high detail, "
+                + "no people, empty venue, atmospheric, cinematic composition, 16:9 aspect ratio, ";
+        return switch (category) {
+            case "CONCERT" -> prefix + "empty concert stage, dramatic stage lighting, " + pal
+                    + " stage gel lights, atmospheric haze, spotlights cutting through fog, "
+                    + "mounted speakers and rigging visible, " + mood + " mood, " + tod + " ambience"
+                    + acc + ", polished black stage floor reflecting lights";
+            case "SPORTS" -> prefix + "empty modern stadium interior, vibrant green turf, "
+                    + "illuminated scoreboard glowing, stadium lights from above, tiered empty seats in distance, "
+                    + pal + " team color accents on banners, " + tod + " sky visible through open roof, "
+                    + mood + " atmosphere" + acc + ", panoramic wide shot";
+            case "MUSICAL" -> prefix + "classical theater stage, deep red velvet curtains parted slightly, "
+                    + "ornate gilded proscenium arch, grand crystal chandelier, warm amber stage lighting, "
+                    + "polished wooden stage floor, empty orchestra pit visible in foreground, "
+                    + pal + " accent lighting, " + mood + " " + tod + " atmosphere" + acc + ", baroque architectural details";
+            case "FANMEETING" -> prefix + "cozy intimate event space, warm fairy lights strung overhead, "
+                    + "pastel " + pal + " balloon arch, decorative bunting and banners, "
+                    + "small empty stage with single chair and microphone stand, soft glowing string lights, "
+                    + mood + " cheerful atmosphere" + acc + ", flower arrangements on tables";
+            case "FESTIVAL" -> prefix + "open-air festival grounds at " + tod + ", "
+                    + "glowing paper lanterns strung between poles, vibrant " + pal + " banners flapping, "
+                    + "empty wooden stage with light truss in background, food stall tents in distance closed, "
+                    + "string lights crisscrossing sky, " + mood + " celebratory mood" + acc;
+            case "EXHIBITION" -> prefix + "minimalist gallery interior, polished concrete floor, "
+                    + "soft track lighting from above, white walls with empty picture frames, "
+                    + "display pedestals with abstract sculptures, " + pal + " accent wall, "
+                    + "floor-to-ceiling windows with " + tod + " natural light, "
+                    + mood + " contemplative atmosphere" + acc + ", architectural depth";
+            default -> prefix + "abstract modern event banner background, "
+                    + "geometric shapes and gradients, " + pal + " color flow, "
+                    + "soft bokeh lights, clean minimalist composition, " + mood + " atmosphere"
+                    + acc + ", sophisticated and versatile";
+        };
+    }
+
+    private String composeNegative(String category) {
+        String common = "people, person, faces, portrait, real person, celebrity, identifiable individual, "
+                + "crowd, audience silhouette, hands, fingers, body parts, "
+                + "text, korean text, english text, watermark, logo, signature, "
+                + "low quality, blurry, distorted, deformed, disfigured, bad anatomy, "
+                + "artifacts, jpeg artifacts, oversaturated, cartoon, anime, 3d render";
+        String extra = switch (category) {
+            case "CONCERT" -> "musicians, band members, performers, ";
+            case "SPORTS" -> "athletes, players, referees, ";
+            case "MUSICAL" -> "actors, dancers, performers in costume, ";
+            case "FANMEETING" -> "idol, k-pop star, fans, autograph, ";
+            case "FESTIVAL" -> "dancers, performers, ";
+            case "EXHIBITION" -> "visitors, gallery viewers, ";
+            default -> "";
+        };
+        return extra + common;
+    }
+
+    private static final String IMAGE_PROMPT_SYSTEM = """
+            당신은 OpenTraum의 이벤트 이미지 prompt 디자이너입니다.
+            주어진 이벤트 메타데이터(카테고리/제목/공연장/아티스트/날짜)를 분석해
+            적절한 분위기·시즌·시간대·색상 팔레트·소품을 추론하세요.
+
+            반드시 build_image_prompt function을 호출하세요. 다음 규칙을 지킵니다.
+            - 인물명/실제 IP는 절대 포함시키지 않습니다 (별도 negative prompt로도 차단됨).
+            - palette는 2~4개의 시각적으로 어울리는 색상 영문 키워드.
+            - accent_objects는 카테고리에 어울리는 소품 영문 키워드 0~5개 (인물 X).
+            """;
+
+    private static final Map<String, Object> BUILD_IMAGE_PROMPT_SCHEMA = Map.of(
+            "name", "build_image_prompt",
+            "description", "이벤트 메타에서 이미지 생성용 시각 디테일을 추론합니다",
+            "parameters", Map.of(
+                    "type", "object",
+                    "properties", Map.of(
+                            "mood", Map.of("type", "string",
+                                    "enum", List.of("energetic", "intimate", "grand", "festive", "calm", "cinematic")),
+                            "season", Map.of("type", "string",
+                                    "enum", List.of("spring", "summer", "autumn", "winter", "any")),
+                            "time_of_day", Map.of("type", "string",
+                                    "enum", List.of("day", "golden_hour", "dusk", "night")),
+                            "palette", Map.of("type", "array",
+                                    "items", Map.of("type", "string"),
+                                    "minItems", 2, "maxItems", 4),
+                            "accent_objects", Map.of("type", "array",
+                                    "items", Map.of("type", "string"),
+                                    "maxItems", 5)
+                    ),
+                    "required", List.of("mood", "season", "time_of_day", "palette")
+            )
+    );
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,21 @@ openai:
   api-key: ${OPENAI_API_KEY:sk-not-needed}
   model: ${OPENAI_MODEL:nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16}
 
+# Track 4 — flux-image / S3 cover 자동 생성
+flux:
+  base-url: ${FLUX_BASE_URL:http://flux-image.opentraum.svc.cluster.local:8000}
+  width: ${FLUX_WIDTH:1024}
+  height: ${FLUX_HEIGHT:576}
+  steps: ${FLUX_STEPS:4}
+  guidance: ${FLUX_GUIDANCE:0.0}
+  candidates: ${FLUX_CANDIDATES:3}
+  request-timeout-seconds: ${FLUX_TIMEOUT_SEC:60}
+
+s3:
+  region: ${AWS_REGION:ap-northeast-2}
+  bucket: ${S3_BUCKET:opentraum-assets}
+  presign-hours: ${S3_PRESIGN_HOURS:24}
+
 management:
   endpoints:
     web:


### PR DESCRIPTION
Closes #54

## 변경
- 신규 endpoint **POST /api/v1/admin/events/cover/generate**
  - Body: \`{ category, title, venue, artist?, dateTime? }\`
  - Resp: \`{ urls: [presigned1, presigned2, presigned3], fallback?: false, model, seconds }\`
- 흐름: Nemotron \`build_image_prompt\` function call → flux-image \`/generate\` (3 candidates) → S3 PutObject → presigned URL 24h
- 폴백: 실패 시 \`defaults/{CATEGORY}.webp\` 1개 presigned

## 신규 파일
- \`config/FluxProperties.java\`, \`config/S3Properties.java\`, \`config/S3ClientConfig.java\`
- \`dto/CoverGenerateRequest.java\`, \`dto/CoverGenerateResponse.java\`
- \`service/EventCoverGenerateService.java\` (220줄)

## 수정
- \`build.gradle\`: AWS SDK v2 BOM 2.29.34 (s3 + auth)
- \`application.yml\`: \`flux\` / \`s3\` 설정 블록
- \`AdminEventController\`: endpoint 1개 추가
- \`k8s/deployment.yml\`: env 5개 (FLUX_BASE_URL / S3_BUCKET / AWS_REGION / AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)

## 사전 작업 (이미 완료)
- opentraum NS Secret \`event-aws-credentials\` 생성됨 (skala_dev AccessKey, 발표 후 회전 약속)
- S3 bucket \`opentraum-assets\` + 7장 default banner 업로드됨 (4.1c)
- flux-image Pod 운영 중 (SDXL Lightning 4-step FP16, 추론 ~2.3s/장)

## Phase 1 (이번 PR — D-2 영상용)
- 동기 endpoint, presigned URL 24h, AccessKey 직접 주입
- Java compileJava: PASS

## Phase 2 (발표 후)
- SSE progress 이벤트
- selected.webp 영구 저장 (CloudFront 또는 public bucket)
- IRSA로 AccessKey 제거

## 영향
- 기존 \`AiEventGenerateService\` 건드리지 않음 (Track 3 production 9.85/10 검증 보존)
- 별도 endpoint라 다른 plain CRUD 흐름 영향 0

## Test plan
- [ ] CI build PASS
- [ ] ArgoCD sync 후 event-service Pod Ready
- [ ] curl POST /api/v1/admin/events/cover/generate (CONCERT) → 3 presigned URL 응답
- [ ] presigned URL 브라우저 접근 → PNG 표시
- [ ] flux-image 일시 죽이고 호출 → fallback default banner URL 응답