### PR TITLE
chore: #56 Pod 자원 재산정

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -112,8 +112,8 @@ spec:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "250m"
+              cpu: "200m"
             limits:
-              memory: "768Mi"
-              cpu: "500m"
+              memory: "512Mi"
+              cpu: "200m"
       restartPolicy: Always


### PR DESCRIPTION
Closes #56

## 변경

### `k8s/deployment.yml`
- `resources.requests.cpu`: `250m` → `200m`
- `resources.requests.memory`: `512Mi` 유지
- `resources.limits.cpu`: `500m` → `200m`
- `resources.limits.memory`: `768Mi` → `512Mi`

## 영향
- QoS: `Burstable` → `Guaranteed` (가장 늦게 evict)
- CPU request 절감: -50m
- Memory limit 축소: -256Mi
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 1개 교체 (`maxSurge: 1`, `maxUnavailable: 0`)
